### PR TITLE
fix: handle http errors in http_text

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -465,7 +465,11 @@ def pattern_search(text: str, key: str, pat: str) -> ExtractResult | None:
 # ── Cached loaders ------------------------------------------------------------
 @st.cache_data(ttl=24 * 60 * 60)
 def http_text(url: str) -> str:
-    html = httpx.get(url, timeout=20).text
+    try:
+        html = httpx.get(url, timeout=20).text
+    except httpx.HTTPError as e:
+        logging.error("HTTP request failed: %s", e)
+        return ""
     return html_text(html)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,3 +28,13 @@ def test_pattern_search_confidence_and_value():
     assert res is not None
     assert res.value == "Alice"
     assert res.confidence == 0.9
+
+
+def test_http_text_handles_http_error(monkeypatch):
+    tool = load_tool_module()
+
+    def raise_error(*args, **kwargs):
+        raise tool.httpx.HTTPError("fail")
+
+    monkeypatch.setattr(tool.httpx, "get", raise_error)
+    assert tool.http_text("http://example.com") == ""


### PR DESCRIPTION
## Summary
- gracefully handle HTTP errors in `http_text`
- add regression test for failed HTTP request

## Testing
- `ruff check Recruitment_Need_Analysis_Tool.py tests/test_utils.py`
- `black Recruitment_Need_Analysis_Tool.py tests/test_utils.py --check`
- `mypy Recruitment_Need_Analysis_Tool.py tests/test_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d05d490988320b297abae77f66cb8