### PR TITLE
fix: populate job title field after extraction

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -968,6 +968,9 @@ def main():
             [2, 20, 6, 20, 2]
         )
 
+        with col_left:
+            url = st.text_input("Job Ad URL", key="job_url")
+
         with col_job:
             job_title = st.text_input(
                 "Job Title",
@@ -1000,12 +1003,12 @@ def main():
                     text = http_text(url)
                 ss["extracted"] = asyncio.run(extract(text))
                 title_res = ss["extracted"].get("job_title")
-                if isinstance(title_res, ExtractResult) and not st.session_state.get(
-                    "job_title"
-                ):
-                    st.session_state.job_title = title_res.value or ""
+                if isinstance(title_res, ExtractResult) and title_res.value:
+                    if not st.session_state.get("job_title"):
+                        st.session_state.job_title = title_res.value
                     ss["data"]["job_title"] = st.session_state.job_title
-                    st.experimental_rerun()
+                    ss["extracted"]["job_title"] = title_res
+                st.experimental_rerun()
 
         if not job_title:
             st.warning("Job Title fehlt – Felder können später ergänzt werden.")


### PR DESCRIPTION
## Summary
- allow pasting a job ad URL
- ensure extracted job title fills the input automatically

## Testing
- `ruff check Recruitment_Need_Analysis_Tool.py`
- `black Recruitment_Need_Analysis_Tool.py --check`
- `timeout 10s mypy Recruitment_Need_Analysis_Tool.py tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d18e577cc8320988a23fbd911f64d