### PR TITLE
feat: extend summary with salary tools

### DIFF
--- a/tests/test_compensation.py
+++ b/tests/test_compensation.py
@@ -1,0 +1,28 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+def load_tool_module():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    spec = importlib.util.spec_from_file_location("tool", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_estimate_salary_range():
+    tool = load_tool_module()
+    out = tool.estimate_salary_range("Data Scientist", "Senior")
+    assert out == "86400–105600 €"
+
+
+def test_calculate_total_compensation():
+    tool = load_tool_module()
+    total = tool.calculate_total_compensation(
+        (50000, 60000), ["Company Car", "Training Budget"]
+    )
+    assert total == 60000 + 5000 + 800


### PR DESCRIPTION
## Summary
- add `generate_text` helper
- overhaul `generate_interview_sheet` and `generate_boolean_search`
- implement salary range estimation and total compensation calculation
- expose salary tools in final summary step
- add tests for new compensation helpers

## Testing
- `ruff check .`
- `black --check .`
- `mypy Recruitment_Need_Analysis_Tool.py tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d28a2ba1483209f51af10840084bb