### PR TITLE
feat: enhance summary tools and salary calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ The wizard collects data in the following order:
 8. TARGET_GROUP
 9. INTERVIEW
 10. SUMMARY
+
+In the final **SUMMARY** step you can generate a job advertisement, an interview
+guide, a Boolean search string and a draft contract. New buttons also let you
+estimate the salary range and calculate the total annual compensation based on
+selected benefits.

--- a/tests/test_compensation.py
+++ b/tests/test_compensation.py
@@ -1,0 +1,27 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+def load_tool_module():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    spec = importlib.util.spec_from_file_location("tool", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_estimate_salary_range_senior_ds():
+    tool = load_tool_module()
+    assert tool.estimate_salary_range("Data Scientist", "Senior") == "86400–105600 €"
+
+
+def test_calculate_total_compensation():
+    tool = load_tool_module()
+    total = tool.calculate_total_compensation(
+        (50000, 60000), ["Company Car", "Health Insurance"]
+    )
+    assert total == 65500


### PR DESCRIPTION
## Summary
- add reusable `generate_text` helper
- improve interview sheet and boolean search generation
- introduce salary range and compensation calculators
- expose new tools in the summary step
- document features in README
- test compensation utilities

## Testing
- `ruff check .`
- `black Recruitment_Need_Analysis_Tool.py tests/*.py`
- `mypy Recruitment_Need_Analysis_Tool.py tests/test_compensation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2d39551483208dc3b81d62bc3fd9