### PR TITLE
feat: dynamic salary chart in skills step

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ streamlit run "Recruitment_Need_Analysis_Tool.py"
 ```
 
 The **SKILLS** step suggests additional hard and soft skills via OpenAI and shows
-them using your current job title for easier selection.
+them using your current job title for easier selection. It also displays a
+dynamic salary chart that predicts the annual salary based on your selected
+skills and other role information.
 
 ## Wizard Steps
 

--- a/tests/test_compensation.py
+++ b/tests/test_compensation.py
@@ -25,3 +25,16 @@ def test_calculate_total_compensation():
         (50000, 60000), ["Company Car", "Health Insurance"]
     )
     assert total == 65500
+
+
+def test_predict_annual_salary_breakdown():
+    tool = load_tool_module()
+    salary, parts = tool.predict_annual_salary(
+        "Engineer",
+        "desc words",
+        "tasks list",
+        "Berlin",
+        ["Python", "SQL"],
+    )
+    assert salary == 30000 + sum(parts.values())
+    assert parts["skills"] == 2000


### PR DESCRIPTION
## Summary
- show a salary prediction graph on the SKILLS page
- compute salary and contributions with `predict_annual_salary`
- test the new salary logic
- document the new feature

## Testing
- `ruff check .`
- `black --check .`
- `mypy --ignore-missing-imports .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d5a1a832c8320a5fbfeb711add023