### PR TITLE
feat: add robust file text extraction

### DIFF
--- a/file_tools.py
+++ b/file_tools.py
@@ -1,0 +1,35 @@
+"""Utility helpers for text extraction from uploaded files."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+from PyPDF2 import PdfReader
+import docx
+
+
+def extract_text_from_file(file_data: bytes, file_type: str) -> str:
+    """Return raw text from a PDF or DOCX file.
+
+    Args:
+        file_data: File content as byte string.
+        file_type: MIME type of the uploaded file.
+
+    Returns:
+        Concatenated text extracted from all pages or paragraphs.
+    """
+    text = ""
+    try:
+        if file_type == "application/pdf":
+            reader = PdfReader(io.BytesIO(file_data))
+            text = "\n".join(page.extract_text() or "" for page in reader.pages).strip()
+        elif file_type in (
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ):
+            doc = docx.Document(io.BytesIO(file_data))
+            text = "\n".join(p.text for p in doc.paragraphs).strip()
+    except Exception as exc:  # pragma: no cover - log only
+        logging.error("Error reading file: %s", exc)
+    return text

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -1,0 +1,52 @@
+import io
+from pathlib import Path
+
+import importlib.util
+import docx
+from fpdf import FPDF
+
+
+def load_file_tools():
+    path = Path(__file__).resolve().parents[1] / "file_tools.py"
+    spec = importlib.util.spec_from_file_location("file_tools", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+extract_text_from_file = load_file_tools().extract_text_from_file
+
+
+def test_extract_text_from_pdf(tmp_path: Path) -> None:
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    pdf.cell(0, 10, "Hello PDF", new_y="NEXT")
+    pdf_bytes = bytes(pdf.output(dest="S"))
+
+    out = extract_text_from_file(pdf_bytes, "application/pdf")
+    assert "Hello PDF" in out
+
+
+def test_extract_text_from_docx(tmp_path: Path) -> None:
+    doc = docx.Document()
+    doc.add_paragraph("Hello DOCX")
+    buf = io.BytesIO()
+    doc.save(buf)
+    out = extract_text_from_file(
+        buf.getvalue(),
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    )
+    assert "Hello DOCX" in out
+
+
+def test_extract_text_handles_errors() -> None:
+    assert extract_text_from_file(b"invalid", "application/pdf") == ""
+    assert (
+        extract_text_from_file(
+            b"invalid",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+        == ""
+    )


### PR DESCRIPTION
## Summary
- extract text from uploaded PDF and DOCX files via new `file_tools` helper
- load helper dynamically in main app so tests can import it
- enhance regex extraction logic
- test the new file extraction routine

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5c6e2d588320afa22317474f7d66