### PR TITLE
feat: improve regex extraction with fallbacks

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,34 @@
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+def load_tool_module():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    spec = importlib.util.spec_from_file_location("tool", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_fallback_patterns(monkeypatch):
+    tool = load_tool_module()
+
+    async def dummy_fill(missing, text):
+        return {}
+
+    monkeypatch.setattr(tool, "llm_fill", dummy_fill)
+    text = (
+        "Wir suchen bei Example GmbH einen Senior Data Scientist (Vollzeit, unbefristet) "
+        "in Berlin. Das Gehalt beträgt 60000 - 70000 EUR."
+    )
+    result = asyncio.run(tool.extract(text))
+    assert result["company_name"].value == "Example GmbH"
+    assert result["employment_type"].value.lower() == "vollzeit"
+    assert result["contract_type"].value.lower() == "unbefristet"
+    assert result["seniority_level"].value.lower().startswith("senior")
+    assert result["salary_range"].value == "60000 - 70000"


### PR DESCRIPTION
## Summary
- extend extraction regex to support more German/English phrases
- add heuristic company name detection
- include fallback regex search in `extract`
- test new extraction behaviour

## Testing
- `black Recruitment_Need_Analysis_Tool.py tests/test_extract.py`
- `ruff check Recruitment_Need_Analysis_Tool.py tests/test_extract.py`
- `mypy Recruitment_Need_Analysis_Tool.py tests/test_extract.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d657ce58c8320960a4fc34ab215be