### PR TITLE
feat: add AI benefit suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ them using your current job title for easier selection. It also displays a
 dynamic salary chart that predicts the annual salary based on your selected
 skills and other role information.
 
+The **BENEFITS** step can now generate benefit suggestions based on the job
+title, the company location and typical competitor offerings. Specify how many
+ideas you want (up to 50) and toggle the ones you like to add them to your
+benefit list.
+
 ## Wizard Steps
 
 The wizard collects data in the following order:

--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -1,0 +1,34 @@
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+import types
+
+
+def load_tool_module():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    spec = importlib.util.spec_from_file_location("tool", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    spec.loader.exec_module(module)
+    return module
+
+
+async def dummy_create(*args, **kwargs):
+    content = '{"benefits": ["B1", "B2"]}'
+    msg = types.SimpleNamespace(content=content)
+    return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg)])
+
+
+def test_suggest_benefits_functions(monkeypatch):
+    tool = load_tool_module()
+    monkeypatch.setattr(tool.client.chat.completions, "create", dummy_create)
+    data = {"job_title": "Engineer", "city": "Berlin"}
+    out1 = asyncio.run(tool.suggest_benefits_by_title(data, 5))
+    out2 = asyncio.run(tool.suggest_benefits_by_location(data, 5))
+    out3 = asyncio.run(tool.suggest_benefits_competitors(data, 5))
+    assert out1 == ["B1", "B2"]
+    assert out2 == ["B1", "B2"]
+    assert out3 == ["B1", "B2"]


### PR DESCRIPTION
## Summary
- add benefit suggestion helpers using OpenAI
- extend BENEFITS step with AI-generated benefit list and selection UI
- show selected benefits in summary overview
- document new feature in README
- cover benefit helpers in tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d74c2b9208320b49e44762a26c63f