### PR TITLE
Add team context suggestions and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ The **BENEFITS** step generates benefit suggestions based on the job title, the
 company location and typical competitor offerings. Each suggestion appears as a
 button that you can toggle to add it to your benefit list.
 
+The **COMPANY & DEPARTMENT** step now groups company information in a clearer
+layout and includes a *Team & Culture Context* expander. Optional fields such as
+Tech Stack and Team Challenges offer a **Generate Ideas** button that fetches AI
+suggestions you can insert directly.
+
 ## Wizard Steps
 
 The wizard collects data in the following order:

--- a/tests/test_team_context.py
+++ b/tests/test_team_context.py
@@ -1,0 +1,36 @@
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+import types
+
+
+def load_tool_module():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    spec = importlib.util.spec_from_file_location("tool", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    spec.loader.exec_module(module)
+    return module
+
+
+async def dummy_create(*args, **kwargs):
+    content = '{"items": ["A", "B"]}'
+    msg = types.SimpleNamespace(content=content)
+    return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg)])
+
+
+def test_team_context_suggestions(monkeypatch):
+    tool = load_tool_module()
+    monkeypatch.setattr(tool.client.chat.completions, "create", dummy_create)
+    data = {"industry": "IT"}
+    out1 = asyncio.run(tool.suggest_team_challenges(data))
+    out2 = asyncio.run(tool.suggest_client_difficulties(data))
+    out3 = asyncio.run(tool.suggest_recent_team_changes(data))
+    out4 = asyncio.run(tool.suggest_tech_stack(data))
+    assert out1 == ["A", "B"]
+    assert out2 == ["A", "B"]
+    assert out3 == ["A", "B"]
+    assert out4 == ["A", "B"]


### PR DESCRIPTION
## Summary
- group company fields in columns and add a Team & Culture expander
- hide `Direct Reports` unless `Supervises` is checked
- add OpenAI helpers to suggest team challenges and related context
- expose new suggestion buttons in the company step
- document new features in the README
- cover new suggestion helpers with tests

## Testing
- `ruff check .`
- `black . --check`
- `mypy Recruitment_Need_Analysis_Tool.py tests/test_team_context.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ebd044d3c83209d734d2c91e7d2cb