### PR TITLE
Merge target group fields into summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ The wizard collects data in the following order:
 3. ROLE & TASKS – responsibilities and key tasks
 4. SKILLS
 5. BENEFITS
-6. TARGET_GROUP
-7. INTERVIEW
-8. SUMMARY
+6. INTERVIEW
+7. SUMMARY – includes Ideal Candidate Profile and Target Industries fields
 
 In the final **SUMMARY** step you can generate a job advertisement, an interview
 guide, a Boolean search string and a draft contract. New buttons also let you

--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -146,7 +146,6 @@ ORDER = [
     "ROLE",
     "SKILLS",
     "BENEFITS",
-    "TARGET_GROUP",
     "INTERVIEW",
     "SUMMARY",
 ]
@@ -1176,10 +1175,6 @@ STEP_SUBTITLES = {
     "BENEFITS": (
         "In diesem Abschnitt werden die Vorteile und Benefits präsentiert, die das Unternehmen bietet. "
         "Attraktive Zusatzleistungen steigern die Arbeitgeberattraktivität und fördern Bewerbungen."
-    ),
-    "TARGET_GROUP": (
-        "Hier analysierst du die Zielgruppe, für die die Position besonders attraktiv ist. "
-        "Durch das Verständnis der Zielgruppe kann die Ansprache und das Sourcing gezielter erfolgen."
     ),
     "INTERVIEW": (
         "Der Interviewprozess und die beteiligten Personen werden in diesem Abschnitt dokumentiert. "
@@ -2450,6 +2445,15 @@ def main():
         display_summary_overview()
         with st.expander("Alle Daten", expanded=False):
             display_summary()
+
+        ss["data"]["ideal_candidate_profile"] = st.text_area(
+            "Ideal Candidate Profile",
+            value=ss["data"].get("ideal_candidate_profile", ""),
+        )
+        ss["data"]["target_industries"] = st.text_area(
+            "Target Industries",
+            value=ss["data"].get("target_industries", ""),
+        )
 
         st.header("Nächster Schritt – Nutzen Sie die gesammelten Daten!")
 


### PR DESCRIPTION
## Summary
- remove TARGET_GROUP wizard step
- show Ideal Candidate Profile and Target Industries on summary page
- update documentation

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686edda766dc8320b7fa5b8e4c809011