### PR TITLE
feat: add interactive salary plot and restructure skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ streamlit run "Recruitment_Need_Analysis_Tool.py"
 
 The **SKILLS** step suggests additional hard and soft skills via OpenAI and
 presents them as selectable buttons. Chosen suggestions are stored in your
-profile. A dynamic salary chart visualises the impact of your selected skills.
-Skills are grouped into language skills, key competencies and other
-requirements for a cleaner layout.
+profile. Skills are grouped into language skills, key competencies and other
+requirements for a cleaner layout. The interactive salary chart now lives in the
+final **SUMMARY** step and shows how different factors influence the expected
+annual salary.
 
 The **BENEFITS** step generates benefit suggestions based on the job title, the
 company location and typical competitor offerings. Each suggestion appears as a

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ python-dotenv
 python-dateutil==2.9.0.post0
 types-python-dateutil
 types-fpdf2
+plotly
 
 # --- development / CI ---
 pre-commit==4.2.0          # hook runner :contentReference[oaicite:5]{index=5}

--- a/wizard_schema.csv
+++ b/wizard_schema.csv
@@ -73,7 +73,7 @@ SKILLS,industry_experience,checkbox,0,Industry Experience,,Branchenerfahrung
 SKILLS,soft_requirement_details,text_area,0,Soft Requirement Details,,Weitere Anforderungen
 SKILLS,years_experience_min,number_input,0,Minimum Years Experience,,Min. Jahre Berufserfahrung
 SKILLS,it_skills,text_area,0,IT Skills,,IT-Kenntnisse
-SKILLS,visa_sponsorship,selectbox,0,Visa Sponsorship,No;Yes;Optional,Visa möglich?
+BENEFITS,visa_sponsorship,selectbox,0,Visa Sponsorship,No;Yes;Optional,Visa möglich?
 BENEFITS,salary_currency,selectbox,1,Salary Currency,EUR;USD;GBP;CHF;PLN;Other,Währung
 BENEFITS,salary_range,text_input,1,Salary Range (EUR),,Bsp.: 50000–65000
 BENEFITS,salary_range_min,number_input,0,Salary Range Min (EUR),,Mindestgehalt


### PR DESCRIPTION
## Summary
- add plotly to requirements
- restructure skills step: move Visa Sponsorship to Benefits, add industry/domain selections
- show interactive salary chart on summary page
- update README about new chart location

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f724b6d1083208f7488098892c39c