### PR TITLE
feat: support bullet prefix in regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ department is highlighted in two columns below the extracted values.
 
 Regex patterns for key information have been tightened and now support German
 and English labels. Extracted values are validated by an LLM to increase
-accuracy.
+accuracy. Labels may now be prefixed with dashes or bullet characters.
 
 ## Wizard Steps
 

--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -206,8 +206,10 @@ def _simple(label_en: str, label_de: str, cap: str) -> str:
     label. It is more restrictive than before to avoid grabbing unrelated text.
     """
 
-    label = rf"(?:{label_en}|{label_de})"
-    return rf"{label}\s*[:\-]?\s*(?P<{cap}>[^\n\r]+)"
+    labels = "|".join(part for part in (label_en, label_de) if part)
+    label = rf"(?:{labels})"
+    bullet = r"^\s*(?:[-*•>]\s*)?"
+    return rf"{bullet}{label}\s*[:\-]?\s*(?P<{cap}>[^\n\r]+)"
 
 
 REGEX_PATTERNS = {

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -55,6 +55,25 @@ def test_extract_label_company(monkeypatch):
     assert result["company_name"].value == "Example GmbH"
 
 
+def test_extract_bullet_prefix(monkeypatch):
+    tool = load_tool_module()
+
+    async def dummy_fill(missing, text):
+        return {}
+
+    async def dummy_validate(data):
+        return {}
+
+    monkeypatch.setattr(tool, "llm_fill", dummy_fill)
+    monkeypatch.setattr(tool, "llm_validate", dummy_validate)
+
+    text = "- Company Name: Example GmbH\n- City: Hamburg\n* Job Title: Engineer"
+    result = asyncio.run(tool.extract(text))
+    assert result["company_name"].value == "Example GmbH"
+    assert result["city"].value == "Hamburg"
+    assert result["job_title"].value == "Engineer"
+
+
 def test_llm_validate(monkeypatch):
     tool = load_tool_module()
 


### PR DESCRIPTION
## Summary
- allow bullet characters before regex labels
- test bullet prefix extraction
- document bullet-aware regex patterns

## Testing
- `ruff check .`
- `mypy Recruitment_Need_Analysis_Tool.py tests/test_extract.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fa66be43c8320b2690b9130023302