### PR TITLE
feat: add city-specific benefits

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ annual salary.
 
 The **BENEFITS** step generates benefit suggestions based on the job title, the
 company location and typical competitor offerings. Each suggestion appears as a
-button that you can toggle to add it to your benefit list.
+button that you can toggle to add it to your benefit list. For some cities the
+app proposes local perks such as club memberships or discounted facilities (for
+example a "Fortuna Düsseldorf" membership when the location is Düsseldorf).
 
 The **COMPANY & DEPARTMENT** step now groups company information in a clearer
 layout and includes a *Team & Culture Context* expander. Optional fields such as

--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -87,6 +87,13 @@ if not api_key:
 
 client = AsyncOpenAI(api_key=api_key)
 
+LOCAL_BENEFITS: dict[str, list[str]] = {
+    "düsseldorf": [
+        "Fortuna Düsseldorf Vereinsmitgliedschaft",
+        "Zugang zur Driving Range auf https://www.golf-duesseldorf.de/driving-range/",
+    ]
+}
+
 
 async def generate_text(
     prompt: str,
@@ -718,6 +725,10 @@ async def _suggest_benefits(data: dict, mode: str, count: int) -> list[str]:
 
     job_title = data.get("job_title", "")
     location = data.get("city") or data.get("work_location_city", "")
+
+    loc_key = location.lower()
+    if mode == "location" and loc_key in LOCAL_BENEFITS:
+        return LOCAL_BENEFITS[loc_key][:count]
 
     if mode == "title":
         prefix = f"for the job title '{job_title}'"


### PR DESCRIPTION
## Summary
- generate city-specific perks for some locations
- mention local perk suggestions in README

## Testing
- `ruff check Recruitment_Need_Analysis_Tool.py`
- `mypy Recruitment_Need_Analysis_Tool.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fb30056e883208f2e949ecab6ab9e