### PR TITLE
Add ESCO API helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,9 @@ In the final **SUMMARY** step you can generate a job advertisement, an interview
 guide, a Boolean search string and a draft contract. New buttons also let you
 estimate the salary range and calculate the total annual compensation based on
 selected benefits.
+
+## ESCO Integration
+
+The tool includes helpers to query the [ESCO REST API](https://ec.europa.eu/esco/api) for
+standardised occupations and skills. Environment variable `ESCO_API_BASE_URL` controls the
+target endpoint.

--- a/esco_api.py
+++ b/esco_api.py
@@ -1,0 +1,76 @@
+"""Helper functions for the ESCO REST API."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+BASE_URL = os.getenv("ESCO_API_BASE_URL", "https://ec.europa.eu/esco/api")
+
+
+def search_occupations(
+    text: str, language: str = "en", limit: int = 10
+) -> list[dict[str, Any]]:
+    """Return occupation matches for the given text."""
+    params = {
+        "text": text,
+        "language": language,
+        "type": "occupation",
+        "limit": str(limit),
+        "full": "false",
+    }
+    try:
+        resp = httpx.get(f"{BASE_URL}/search", params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("_embedded", {}).get("results", [])
+    except httpx.HTTPError as exc:  # pragma: no cover - log only
+        logging.error("ESCO search failed: %s", exc)
+        return []
+
+
+def get_skills_for_occupation(
+    occupation_uri: str,
+    *,
+    relation: str = "isEssentialForSkill",
+    language: str = "en",
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Return skills related to an occupation URI."""
+    params = {
+        "uri": occupation_uri,
+        "relation": relation,
+        "language": language,
+        "limit": str(limit),
+    }
+    try:
+        resp = httpx.get(f"{BASE_URL}/resource/related", params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("_embedded", {}).get(relation, [])
+    except httpx.HTTPError as exc:  # pragma: no cover - log only
+        logging.error("ESCO related lookup failed: %s", exc)
+        return []
+
+
+def suggest(
+    text: str, *, type_: str, language: str = "en", limit: int = 10
+) -> list[dict[str, Any]]:
+    """Return autocomplete suggestions for skills or occupations."""
+    params = {
+        "text": text,
+        "language": language,
+        "type": type_,
+        "limit": str(limit),
+    }
+    try:
+        resp = httpx.get(f"{BASE_URL}/suggest2", params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("_embedded", {}).get("results", [])
+    except httpx.HTTPError as exc:  # pragma: no cover - log only
+        logging.error("ESCO suggest failed: %s", exc)
+        return []

--- a/tests/test_esco.py
+++ b/tests/test_esco.py
@@ -1,0 +1,60 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_module():
+    path = Path(__file__).resolve().parents[1] / "esco_api.py"
+    spec = importlib.util.spec_from_file_location("esco_api", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self) -> None:  # pragma: no cover - dummy
+        pass
+
+    def json(self):
+        return self._data
+
+
+class DummyClient:
+    def __init__(self, data):
+        self.data = data
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def get(self, url, params=None, timeout=10):
+        return DummyResponse(self.data)
+
+
+def test_search_occupations(monkeypatch):
+    mod = load_module()
+    data = {"_embedded": {"results": [{"label": "Nurse"}]}}
+    monkeypatch.setattr(mod.httpx, "get", DummyClient(data).get)
+    res = mod.search_occupations("nurse")
+    assert res == data["_embedded"]["results"]
+
+
+def test_get_skills_for_occupation(monkeypatch):
+    mod = load_module()
+    relation = "isEssentialForSkill"
+    data = {"_embedded": {relation: [{"uri": "skill1"}]}}
+    monkeypatch.setattr(mod.httpx, "get", DummyClient(data).get)
+    res = mod.get_skills_for_occupation("occ", relation=relation)
+    assert res == data["_embedded"][relation]
+
+
+def test_suggest(monkeypatch):
+    mod = load_module()
+    data = {"_embedded": {"results": [{"label": "abc"}]}}
+    monkeypatch.setattr(mod.httpx, "get", DummyClient(data).get)
+    res = mod.suggest("a", type_="skill")
+    assert res == data["_embedded"]["results"]


### PR DESCRIPTION
## Summary
- provide `esco_api` module to access ESCO REST endpoints
- cover helper with tests
- document ESCO base URL

## Testing
- `ruff check esco_api.py tests/test_esco.py`
- `mypy esco_api.py tests/test_esco.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fbbd53b308320a839d7fd191ad35c