### PR TITLE
Integrate ESCO lookup in skill wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ selected benefits.
 
 The tool includes helpers to query the [ESCO REST API](https://ec.europa.eu/esco/api) for
 standardised occupations and skills. Environment variable `ESCO_API_BASE_URL` controls the
-target endpoint.
+target endpoint. Occupation lookup and ESCO skill suggestions are available directly in the **SKILLS** step.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -34,3 +34,17 @@ def test_suggest_hard_skills(monkeypatch):
     data = {"job_title": "Engineer"}
     out = asyncio.run(tool.suggest_hard_skills(data))
     assert out == ["SkillA", "SkillB"]
+
+
+def test_get_esco_skills(monkeypatch):
+    tool = load_tool_module()
+
+    monkeypatch.setattr(tool, "search_occupations", lambda q, limit=1: [{"uri": "u"}])
+    monkeypatch.setattr(
+        tool,
+        "get_skills_for_occupation",
+        lambda uri, limit=20: [{"title": "Skill1"}, {"label": "Skill2"}],
+    )
+
+    res = tool.get_esco_skills("nurse")
+    assert res == ["Skill1", "Skill2"]


### PR DESCRIPTION
## Summary
- wire up ESCO API module in the wizard
- add helper `get_esco_skills` and UI for occupation lookup
- extend skill tests for ESCO integration
- document ESCO suggestions in README

## Testing
- `ruff check Recruitment_Need_Analysis_Tool.py tests/test_skills.py esco_api.py`
- `mypy Recruitment_Need_Analysis_Tool.py esco_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc93b5c1083209cddc1d93c3fc258