### PR TITLE
fix: correct default relation for ESCO skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,6 @@ selected benefits.
 The tool includes helpers to query the [ESCO REST API](https://ec.europa.eu/esco/api) for
 standardised occupations and skills. Environment variable `ESCO_API_BASE_URL` controls the
 target endpoint. Occupation lookup and ESCO skill suggestions are available directly in the **SKILLS** step.
+
+The helper uses the ``hasEssentialSkill`` relation to fetch essential skills for
+an occupation from the ESCO API.

--- a/esco_api.py
+++ b/esco_api.py
@@ -35,11 +35,15 @@ def search_occupations(
 def get_skills_for_occupation(
     occupation_uri: str,
     *,
-    relation: str = "isEssentialForSkill",
+    relation: str = "hasEssentialSkill",
     language: str = "en",
     limit: int = 20,
 ) -> list[dict[str, Any]]:
-    """Return skills related to an occupation URI."""
+    """Return skills related to an occupation URI.
+
+    By default uses the ``hasEssentialSkill`` relation which matches the
+    ESCO API and retrieves skills essential for the given occupation.
+    """
     params = {
         "uri": occupation_uri,
         "relation": relation,


### PR DESCRIPTION
## Summary
- default to `hasEssentialSkill` when retrieving ESCO skills
- document ESCO relation in README

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fd25cbc9883209da8895fbd00d34d