### PR TITLE
feat: add salary range slider

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -1074,6 +1074,26 @@ def show_input(
             label, value=str(val).lower() == "true", key=widget_key, help=helptext
         )
 
+    elif field_type == "slider":
+        digits = [int(x) for x in re.findall(r"\d+", str(val))]
+        if len(digits) >= 2:
+            default_range = (digits[0], digits[1])
+        elif len(digits) == 1:
+            default_range = (digits[0], digits[0])
+        else:
+            default_range = (50000, 60000)
+
+        selected = st.slider(
+            label,
+            min_value=0,
+            max_value=200000,
+            value=default_range,
+            step=1000,
+            key=widget_key,
+            help=helptext,
+        )
+        val = f"{selected[0]}–{selected[1]}"
+
     else:
         val = st.text_input(label, value=val or "", key=widget_key, help=helptext)
 

--- a/wizard_schema.csv
+++ b/wizard_schema.csv
@@ -6,7 +6,7 @@ BASIC,date_of_employment_start,date_input,0,Start Date Target,,Geplantes Startda
 BASIC,work_schedule,selectbox,0,Work Schedule,Full-time;Part-time;Flexitime;Shift;Weekend;Night;Remote;Hybrid,Arbeitszeitmodell auswählen
 BASIC,work_location_city,text_input,1,Work Location City,,Arbeitsort (Stadt)
 BASIC,salary_currency,selectbox,1,Salary Currency,EUR;USD;GBP;CHF;PLN;Other,Währung
-BASIC,salary_range,text_input,1,Salary Range (EUR),,Bsp.: 50000–65000
+BASIC,salary_range,slider,1,Salary Range (EUR),,Bsp.: 50000–60000
 BASIC,pay_frequency,selectbox,1,Pay Frequency,Monthly;Yearly;Weekly;Bi-Weekly;Quarterly,Zahlungsintervall
 COMPANY,company_name,text_input,1,Company Name,,Firmenname
 COMPANY,city,text_input,1,Company City,,Stadt (Sitz der Firma)


### PR DESCRIPTION
## Summary
- change `salary_range` field to a slider in schema
- implement generic slider input handling with default range 50k–60k

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fd8a1407483208d7e22d833c36dba