### PR TITLE
fix: enable salary slider editing

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -1745,6 +1745,7 @@ def main():
     ss.setdefault("data", {})
     ss.setdefault("extracted", {})
     ss.setdefault("benefit_list", [])
+    ss["_used_widget_keys"] = set()
 
     def goto(i: int):
         ss["step"] = i


### PR DESCRIPTION
## Summary
- reset session key tracking each run so widget keys stay stable

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fe0c896b083209b0663c97c1981a8