### PR TITLE
Remove job title field from basic wizard step

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -1878,13 +1878,6 @@ def main():
 
         if step_name == "BASIC":
             meta_map = {m["key"]: m for m in meta_fields}
-            if value_missing("job_title"):
-                show_input(
-                    "job_title",
-                    extr.get("job_title", ExtractResult()),
-                    meta_map["job_title"],
-                    widget_prefix=step_name,
-                )
 
             cols = st.columns(2)
             with cols[0]:

--- a/wizard_schema.csv
+++ b/wizard_schema.csv
@@ -1,5 +1,4 @@
 step,key,field_type,is_must,label,options,helptext
-BASIC,job_title,text_input,1,Job Title,,Bitte den exakten Jobtitel angeben
 BASIC,employment_type,selectbox,1,Employment Type,Full-time;Part-time;Freelance;Internship;Werkstudent;Praktikum;Mini-Job;Other,Beschäftigungsart auswählen
 BASIC,contract_type,selectbox,1,Contract Type,Permanent;Temporary;Fixed-Term;Freelancer;Project;Aushilfe;Werkvertrag;Zeitarbeit,Vertragsart auswählen
 BASIC,date_of_employment_start,date_input,0,Start Date Target,,Geplantes Startdatum


### PR DESCRIPTION
## Summary
- stop rendering the job_title field in the BASIC step
- delete job_title row from `wizard_schema.csv`

## Testing
- `ruff check .`
- `black --check .`
- `mypy --ignore-missing-imports .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ff47c14bc83209797bcdb9310fdbf