### PR TITLE
feat: expand regex for job and employment

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -240,14 +240,23 @@ def _simple(label_en: str, label_de: str, cap: str) -> str:
 
 REGEX_PATTERNS = {
     # BASIC INFO - mandatory
-    "job_title": _simple("Job\\s*Title|Position|Stellenbezeichnung", "", "job_title"),
+    "job_title": _simple(
+        "Job\\s*Title|Position|Jobtitel|Stellentitel|Berufsbezeichnung",
+        "",
+        "job_title",
+    ),
     "employment_type": _simple(
-        "Employment\\s*Type",
-        "Vertragsart|Beschäftigungsart|Arbeitszeit",
+        "Employment\\s*Type|Work\\s*Type",
+        (
+            "Vertragsart|Beschäftigungsart|Arbeitszeit|Anstellungsart|"
+            "Beschäftigungsverhältnis|Art\\s*der\\s*Beschäftigung|Arbeitszeitmodell"
+        ),
         "employment_type",
     ),
     "contract_type": _simple(
-        "Contract\\s*Type", "Vertragstyp|Anstellungsart", "contract_type"
+        "Contract\\s*Type|Type\\s*of\\s*Contract",
+        "Vertragstyp|Anstellungsart|Art\\s*des\\s*Vertrags",
+        "contract_type",
     ),
     "seniority_level": _simple(
         "Seniority\\s*Level", "Karrierelevel", "seniority_level"
@@ -538,8 +547,16 @@ LLM_PROMPT = (
 
 # Additional lightweight patterns without explicit labels
 FALLBACK_PATTERNS: dict[str, str] = {
-    "employment_type": r"(?P<employment_type>Vollzeit|Teilzeit|Werkstudent(?:[ei]n)?|Praktikum|Mini[-\s]?Job|Freelance|Internship|Full[-\s]?time|Part[-\s]?time)",
-    "contract_type": r"(?P<contract_type>unbefristet|befristet|festanstellung|permanent|temporary|fixed[-\s]?term|contract|freelancer|project|werkvertrag|zeitarbeit)",
+    "employment_type": (
+        r"(?P<employment_type>Vollzeit|Teilzeit|Teilzeitkraft|Werkstudent(?:[ei]n)?|"
+        r"Praktikum|Mini[-\s]?Job|Freelance|Freelancer|Freiberuflich|"
+        r"Internship|Full[-\s]?time|Part[-\s]?time)"
+    ),
+    "contract_type": (
+        r"(?P<contract_type>unbefristet|befristet|befristeter\s*Vertrag|"
+        r"festanstellung|permanent|temporary|fixed[-\s]?term|contract|"
+        r"freelancer|project|werkvertrag|zeitarbeit|project[-\s]?based)"
+    ),
     "seniority_level": r"(?P<seniority_level>Junior|Mid|Senior|Lead|Head|Manager|Einsteiger|Berufserfahren)",
     "salary_range": r"(?P<salary_range>\d{4,6}\s*(?:-|bis|to|–)\s*\d{4,6})",
     "work_location_city": r"\bin\s+(?P<work_location_city>[A-ZÄÖÜ][A-Za-zÄÖÜäöüß.-]{2,}(?:\s+[A-ZÄÖÜ][A-Za-zÄÖÜäöüß.-]{2,})?)",

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -74,6 +74,24 @@ def test_extract_bullet_prefix(monkeypatch):
     assert result["job_title"].value == "Engineer"
 
 
+def test_extract_synonym_labels(monkeypatch):
+    tool = load_tool_module()
+
+    async def dummy_fill(missing, text):
+        return {}
+
+    async def dummy_validate(data):
+        return {}
+
+    monkeypatch.setattr(tool, "llm_fill", dummy_fill)
+    monkeypatch.setattr(tool, "llm_validate", dummy_validate)
+
+    text = "Jobtitel: Data Engineer\n" "Beschäftigungsverhältnis: Teilzeit"
+    result = asyncio.run(tool.extract(text))
+    assert result["job_title"].value == "Data Engineer"
+    assert result["employment_type"].value.lower() == "teilzeit"
+
+
 def test_llm_validate(monkeypatch):
     tool = load_tool_module()
 


### PR DESCRIPTION
## Summary
- extend REGEX_PATTERNS for job title, employment and contract type
- broaden FALLBACK_PATTERNS for employment and contract types
- cover new labels via unit test

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68703046f4d08320984e5cb53683fb98