### PR TITLE
feat: add spaCy NER fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ that the extraction finished.
 Regex patterns for key information have been tightened and now support German
 and English labels. Extracted values are validated by an LLM to increase
 accuracy. Labels may now be prefixed with dashes or bullet characters.
+If the patterns fail, a lightweight spaCy NER model guesses the company name
+and city from the text.
 
 ## Wizard Steps
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ types-python-dateutil
 types-fpdf2
 plotly
 spacy==3.8.7
-xx-ent-wiki-sm==3.8.0
+https://github.com/explosion/spacy-models/releases/download/xx_ent_wiki_sm-3.8.0/xx_ent_wiki_sm-3.8.0-py3-none-any.whl
 
 # --- development / CI ---
 pre-commit==4.2.0          # hook runner :contentReference[oaicite:5]{index=5}

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ python-dateutil==2.9.0.post0
 types-python-dateutil
 types-fpdf2
 plotly
+spacy==3.8.7
+xx-ent-wiki-sm==3.8.0
 
 # --- development / CI ---
 pre-commit==4.2.0          # hook runner :contentReference[oaicite:5]{index=5}

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -92,6 +92,27 @@ def test_extract_synonym_labels(monkeypatch):
     assert result["employment_type"].value.lower() == "teilzeit"
 
 
+def test_extract_ner_fallback(monkeypatch):
+    tool = load_tool_module()
+
+    async def dummy_fill(missing, text):
+        return {}
+
+    async def dummy_validate(data):
+        return {}
+
+    monkeypatch.setattr(tool, "llm_fill", dummy_fill)
+    monkeypatch.setattr(tool, "llm_validate", dummy_validate)
+
+    text = (
+        "Join S3 Solutions GmbH as Data Scientist. "
+        "The position is based at our Munich office."
+    )
+    result = asyncio.run(tool.extract(text))
+    assert result["company_name"].value == "S3 Solutions GmbH"
+    assert result["work_location_city"].value == "Munich"
+
+
 def test_llm_validate(monkeypatch):
     tool = load_tool_module()
 


### PR DESCRIPTION
## Summary
- use spaCy's `xx_ent_wiki_sm` model to guess company names and cities
- fallback only if regex patterns couldn't detect them
- expand `search_company_name` checks
- describe new functionality in README
- add dependency requirements and tests for NER fallback

## Testing
- `ruff check .`
- `black --check .`
- `mypy Recruitment_Need_Analysis_Tool.py file_tools.py esco_api.py tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68703403e4108320b56f32eedb0167e4