### PR TITLE
feat: sanitize llm output values

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,3 +38,10 @@ def test_http_text_handles_http_error(monkeypatch):
 
     monkeypatch.setattr(tool.httpx, "get", raise_error)
     assert tool.http_text("http://example.com") == ""
+
+
+def test_sanitize_value():
+    tool = load_tool_module()
+    assert tool.sanitize_value("  Foo \n") == "Foo"
+    assert tool.sanitize_value(12.0) == "12"
+    assert tool.sanitize_value(None) is None


### PR DESCRIPTION
## Summary
- clean whitespace and digits via `sanitize_value`
- apply sanitation in regex search and LLM helpers
- sanitize list suggestions from the API
- test the new sanitizer utility

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68739f16a9a08320b8c50d9e78d03971