### PR TITLE
feat: support job URL input

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The **COMPANY & DEPARTMENT** step groups company info in a cleaner layout. The
 **Generate Ideas** button above the input and AI suggestions appear as pill
 buttons. Missing data remains highlighted in two columns below the extracted
 values. After uploading a file a small success message with a 🔥 icon confirms
-that the extraction finished.
+that the extraction finished. You can also paste a job ad URL to analyse the
+posting directly.
 
 Regex patterns for key information have been tightened and now support German
 and English labels. Extracted values are validated by an LLM to increase

--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -1955,6 +1955,43 @@ def main():
                 label_visibility="visible",
             )
 
+            url = st.text_input(
+                "Stellen-URL" if lang_label == "Deutsch" else "Job Ad URL",
+                key="job_url",
+            )
+
+            if st.button(
+                "URL analysieren" if lang_label == "Deutsch" else "Parse URL",
+                key="fetch_url",
+            ):
+                if url:
+                    if ss.get("parsed_url") != url:
+                        with status_box.container():
+                            with st.spinner("Extracting…"):
+                                text = http_text(url)
+                                if text:
+                                    flat = asyncio.run(extract(text))
+                                    ss["extracted"] = group_by_step(flat)
+                                    title_res = (
+                                        ss["extracted"]
+                                        .get("BASIC", {})
+                                        .get("job_title")
+                                    )
+                                    if (
+                                        isinstance(title_res, ExtractResult)
+                                        and title_res.value
+                                    ):
+                                        ss["data"]["job_title"] = title_res.value
+                                    ss["parsed_url"] = url
+                        ss["extraction_success"] = True
+                        st.rerun()
+                else:
+                    status_box.warning(
+                        "Bitte eine URL eingeben"
+                        if lang_label == "Deutsch"
+                        else "Please enter a URL"
+                    )
+
             up = st.file_uploader(
                 (
                     "Stellenbeschreibung hochladen (PDF oder DOCX)"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,6 +40,12 @@ def test_http_text_handles_http_error(monkeypatch):
     assert tool.http_text("http://example.com") == ""
 
 
+def test_html_text_removes_scripts():
+    tool = load_tool_module()
+    html = "<p>Hello</p><script>alert(1)</script>"
+    assert tool.html_text(html) == "Hello"
+
+
 def test_sanitize_value():
     tool = load_tool_module()
     assert tool.sanitize_value("  Foo \n") == "Foo"


### PR DESCRIPTION
## Summary
- allow analysing job ads via URL
- document URL parsing support
- test HTML text extraction

## Testing
- `ruff check Recruitment_Need_Analysis_Tool.py tests/test_utils.py`
- `mypy Recruitment_Need_Analysis_Tool.py tests/test_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873a20fef2c8320940619d1db69b414