### PR TITLE
Add vector search for RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ target endpoint. Occupation lookup and ESCO skill suggestions are available dire
 
 The helper uses the ``hasEssentialSkill`` relation to fetch essential skills for
 an occupation from the ESCO API.
+
+## Vector Search
+
+Missing fields can be filled via Retrieval-Augmented Generation. Relevant job ads
+and CV snippets are retrieved from the pre-trained "vacalyser" vector store and
+passed to the LLM. Set ``VACALYSER_VECTOR_STORE`` to override the default store
+ID.

--- a/services/vector_search.py
+++ b/services/vector_search.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+from openai import AsyncOpenAI
+
+STORE_ID = os.getenv(
+    "VACALYSER_VECTOR_STORE",
+    "vs_67e40071e7608191a62ab06cacdcdd10",
+)
+
+
+class VectorStore:
+    """Wrapper for OpenAI Vector Store search."""
+
+    def __init__(
+        self, client: AsyncOpenAI | None = None, store_id: str | None = None
+    ) -> None:
+        self.client = client or AsyncOpenAI()
+        self.store_id = store_id or STORE_ID
+
+    async def search(self, query: str, *, top_k: int = 5) -> List[str]:
+        """Return snippet texts most relevant to the query."""
+        paginator = await self.client.vector_stores.search(
+            self.store_id,
+            query=query,
+            max_num_results=top_k,
+        )
+        results: List[str] = []
+        async for item in paginator:
+            text = " ".join(chunk.text for chunk in item.content if chunk.text)
+            results.append(text)
+        return results

--- a/tests/test_llm_fill.py
+++ b/tests/test_llm_fill.py
@@ -1,0 +1,33 @@
+import asyncio
+import types
+import importlib.util
+import os
+from pathlib import Path
+
+
+def load_tool_module():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    spec = importlib.util.spec_from_file_location("tool", path)
+    module = importlib.util.module_from_spec(spec)
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    spec.loader.exec_module(module)
+    return module
+
+
+async def dummy_create(*args, **kwargs):
+    return types.SimpleNamespace(
+        choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="{}"))]
+    )
+
+
+async def dummy_search(query, top_k=3):
+    dummy_search.called = query
+    return ["ctx"]
+
+
+def test_llm_fill_includes_context(monkeypatch):
+    tool = load_tool_module()
+    monkeypatch.setattr(tool.client.chat.completions, "create", dummy_create)
+    monkeypatch.setattr(tool.vector_store, "search", dummy_search)
+    asyncio.run(tool.llm_fill(["job_title"], "some text"))
+    assert dummy_search.called == "some text"[:1000]

--- a/tests/test_vector_search.py
+++ b/tests/test_vector_search.py
@@ -1,0 +1,29 @@
+import asyncio
+import types
+import importlib.util
+from pathlib import Path
+
+
+def test_vector_search_returns_text(monkeypatch):
+    path = Path(__file__).resolve().parents[1] / "services" / "vector_search.py"
+    spec = importlib.util.spec_from_file_location("vector_search", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    class DummyPaginator:
+        def __aiter__(self):
+            async def gen():
+                yield types.SimpleNamespace(content=[types.SimpleNamespace(text="foo")])
+
+            return gen()
+
+    class DummyClient:
+        def __init__(self) -> None:
+            async def search(*args, **kwargs):
+                return DummyPaginator()
+
+            self.vector_stores = types.SimpleNamespace(search=search)
+
+    vs = module.VectorStore(client=DummyClient(), store_id="id")
+    result = asyncio.run(vs.search("bar"))
+    assert result == ["foo"]


### PR DESCRIPTION
## Summary
- add OpenAI vector store wrapper and integrate into llm_fill
- create tests for vector store usage
- document vector search capabilities in README

## Testing
- `ruff check Recruitment_Need_Analysis_Tool.py services/vector_search.py tests/test_vector_search.py tests/test_llm_fill.py`
- `mypy Recruitment_Need_Analysis_Tool.py services/vector_search.py tests/test_vector_search.py tests/test_llm_fill.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873a4a98e78832088aaa478e441149a