### PR TITLE
feat: add local vector search with faiss

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ python-dotenv
 python-dateutil==2.9.0.post0
 types-python-dateutil
 types-fpdf2
+sentence-transformers
+faiss-cpu
 plotly
 spacy==3.8.7
 https://github.com/explosion/spacy-models/releases/download/xx_ent_wiki_sm-3.8.0/xx_ent_wiki_sm-3.8.0-py3-none-any.whl

--- a/services/vector_search.py
+++ b/services/vector_search.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import os
-from typing import List
+from typing import List, Sequence
 
+import faiss
+import numpy as np
 from openai import AsyncOpenAI
+from sentence_transformers import SentenceTransformer
 
 STORE_ID = os.getenv(
     "VACALYSER_VECTOR_STORE",
@@ -32,3 +35,41 @@ class VectorStore:
             text = " ".join(chunk.text for chunk in item.content if chunk.text)
             results.append(text)
         return results
+
+
+class LocalVectorStore:
+    """Simple FAISS-based vector store using SentenceTransformers."""
+
+    def __init__(
+        self,
+        texts: Sequence[str] | None = None,
+        *,
+        model: SentenceTransformer | None = None,
+    ) -> None:
+        self.model = model or SentenceTransformer(
+            os.getenv("VACALYSER_EMBED_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+        )
+        self.texts: list[str] = list(texts or [])
+        dim = self.model.get_sentence_embedding_dimension()
+        self.index = faiss.IndexFlatL2(dim)
+        if self.texts:
+            self._add(self.texts)
+
+    def _add(self, texts: Sequence[str]) -> None:
+        vecs = self.model.encode(list(texts))
+        self.index.add(np.asarray(vecs, dtype="float32"))
+
+    def add(self, texts: Sequence[str]) -> None:
+        """Add documents to the index."""
+
+        self.texts.extend(texts)
+        self._add(texts)
+
+    def search(self, query: str, *, top_k: int = 5) -> list[str]:
+        """Return texts with vectors closest to the query."""
+
+        if self.index.ntotal == 0:
+            return []
+        vec = self.model.encode([query])
+        distances, indices = self.index.search(np.asarray(vec, dtype="float32"), top_k)
+        return [self.texts[i] for i in indices[0] if i < len(self.texts)]

--- a/tests/test_faiss_vector_search.py
+++ b/tests/test_faiss_vector_search.py
@@ -1,0 +1,22 @@
+import importlib.util
+from pathlib import Path
+
+
+def test_local_vector_store_search():
+    path = Path(__file__).resolve().parents[1] / "services" / "vector_search.py"
+    spec = importlib.util.spec_from_file_location("vector_search", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    class DummyModel:
+        def get_sentence_embedding_dimension(self):
+            return 2
+
+        def encode(self, texts):
+            if isinstance(texts, list):
+                return [[len(t), len(set(t))] for t in texts]
+            return [[len(texts), len(set(texts))]]
+
+    store = module.LocalVectorStore(texts=["foo", "bar"], model=DummyModel())
+    result = store.search("foo", top_k=1)
+    assert result == ["foo"]


### PR DESCRIPTION
## Summary
- extend vector search module with LocalVectorStore using SentenceTransformers and FAISS
- install sentence-transformers and faiss-cpu
- test LocalVectorStore behaviour

## Testing
- `ruff check`
- `black --check services/vector_search.py tests/test_faiss_vector_search.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b8d8c1b8832092468d7872a9208a