### PR TITLE
Add retrieval chain using LangChain

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,7 @@ flake8==7.3.0              # linter/quality checks :contentReference[oaicite:9]{
 types-requests==2.32.4.20250611  # typing stubs for “requests” :contentReference[oaicite:10]{index=10}
 lxml==5.2.1
 pdfplumber
+
+langchain
+langchain-openai
+

--- a/services/langchain_chain.py
+++ b/services/langchain_chain.py
@@ -1,0 +1,75 @@
+"""LangChain orchestration helpers."""
+
+from __future__ import annotations
+import logging
+
+
+import httpx
+from bs4 import BeautifulSoup
+from langchain_core.runnables import Runnable
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from langchain_openai import ChatOpenAI
+
+import importlib.util
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+_vs_spec = importlib.util.spec_from_file_location(
+    "vector_search", Path(__file__).resolve().parent / "vector_search.py"
+)
+assert _vs_spec is not None
+_vs_mod = importlib.util.module_from_spec(_vs_spec)
+assert _vs_spec.loader is not None
+_vs_spec.loader.exec_module(_vs_mod)
+VectorStore = _vs_mod.VectorStore
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from services.vector_search import VectorStore as VectorStoreType
+
+
+async def fetch_url_text(url: str) -> str:
+    """Return cleaned text extracted from an URL."""
+    try:
+        resp = httpx.get(url, timeout=10)
+        resp.raise_for_status()
+    except httpx.HTTPError as exc:
+        logging.error("URL fetch failed: %s", exc)
+        return ""
+    soup = BeautifulSoup(resp.text, "html.parser")
+    return soup.get_text(separator="\n").strip()
+
+
+async def run_chain(
+    url: str,
+    question: str,
+    *,
+    vector_store: "VectorStoreType",
+    client: ChatOpenAI | None = None,
+    top_k: int = 5,
+) -> str:
+    """Execute the retrieval and LLM chain."""
+    url_text = await fetch_url_text(url)
+    snippets = await vector_store.search(question, top_k=top_k)
+    llm = client or ChatOpenAI(model="gpt-4o", temperature=0)
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", "Answer the user question based on the provided context."),
+            (
+                "human",
+                "URL CONTENT:\n{url_text}\n\nOTHER CONTEXT:\n{context}\n\nQUESTION:\n{question}",
+            ),
+        ]
+    )
+    chain: Runnable[dict, str] = prompt | llm | StrOutputParser()
+    return await chain.ainvoke(
+        {
+            "url_text": url_text[:5000],
+            "context": "\n".join(snippets),
+            "question": question,
+        }
+    )
+
+
+__all__ = ["fetch_url_text", "run_chain"]

--- a/tests/test_langchain_chain.py
+++ b/tests/test_langchain_chain.py
@@ -1,0 +1,51 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+
+
+def load_module():
+    path = Path(__file__).resolve().parents[1] / "services" / "langchain_chain.py"
+    spec = importlib.util.spec_from_file_location("chain", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+
+class DummyVectorStore:
+    called: str | None = None
+
+    async def search(self, query: str, top_k: int = 5):
+        DummyVectorStore.called = query
+        return ["snippet"]
+
+
+class DummyLLM:
+    called: dict | None = None
+
+    async def ainvoke(self, data):
+        DummyLLM.called = data
+        return "answer"
+
+    def __call__(self, data):
+        return asyncio.run(self.ainvoke(data))
+
+
+def test_run_chain(monkeypatch):
+    mod = load_module()
+
+    def dummy_get(url, timeout=10):
+        class Resp:
+            text = "<p>hello</p>"
+
+            def raise_for_status(self) -> None:
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr(mod.httpx, "get", dummy_get)
+    vs = DummyVectorStore()
+    llm = DummyLLM()
+    out = asyncio.run(mod.run_chain("http://x", "q?", vector_store=vs, client=llm))
+    assert out == "answer"
+    assert DummyVectorStore.called == "q?"
+    assert "hello" in DummyLLM.called.messages[1].content


### PR DESCRIPTION
## Summary
- use LangChain to build a small URL+vector search chain
- add async chain helper with dynamic import of VectorStore
- cover the chain with a unit test
- include LangChain dependencies

## Testing
- `ruff check .`
- `black . --check`
- `mypy --ignore-missing-imports .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873bb9278548320895986de89f80993