### PR TITLE
Add validation and retry for LLM JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ and English labels. Extracted values are validated by an LLM to increase
 accuracy. Labels may now be prefixed with dashes or bullet characters.
 If the patterns fail, a lightweight spaCy NER model guesses the company name
 and city from the text.
+LLM outputs are checked for missing fields and invalid JSON. If issues are detected the
+assistant automatically re-prompts the model with clarification to improve the extraction.
 
 ## Wizard Steps
 


### PR DESCRIPTION
## Summary
- add `json_chat` helper to validate JSON output and retry missing keys
- retry extraction for missing mandatory fields
- test LLM retry logic
- document improved validation in README

## Testing
- `ruff check .`
- `black --check .`
- `mypy Recruitment_Need_Analysis_Tool.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c1be9e348320a07433eeacc71f6b