### PR TITLE
fix: localize ESCO description

### DIFF
--- a/tests/test_esco.py
+++ b/tests/test_esco.py
@@ -62,10 +62,14 @@ def test_suggest(monkeypatch):
 
 def test_fetch_occupation_details(monkeypatch):
     mod = load_module()
-    data = {"description": "desc"}
+    data = {
+        "description": {"en": {"literal": "desc"}},
+        "preferredLabel": {"en": "Manager"},
+    }
     monkeypatch.setattr(mod.httpx, "get", DummyClient(data).get)
     res = mod.fetch_occupation_details("uri")
-    assert res == data
+    assert res["description"] == "desc"
+    assert res["preferredLabel"] == "Manager"
 
 
 def test_bulk_search_occupations(monkeypatch):


### PR DESCRIPTION
## Summary
- extract localized text from ESCO API metadata
- test new helper

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c89b9f488320ac0b1ad767ca592a