### PR TITLE
feat: auto parse URLs and extend benefits

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ annual salary.
 The **BENEFITS** step generates benefit suggestions based on the job title, the
 company location and typical competitor offerings. Each suggestion appears as a
 button that you can toggle to add it to your benefit list. For some cities the
-app proposes local perks such as club memberships or discounted facilities (for
-example a "Fortuna Düsseldorf" membership when the location is Düsseldorf).
+app proposes local perks such as club memberships or discounted facilities
+(e.g. "Fortuna Düsseldorf" membership). Regional perks now also exist for
+Berlin, München, Hamburg and Frankfurt.
 
 The **COMPANY & DEPARTMENT** step groups company info in a cleaner layout. The
 *Team & Culture Context* now shows three bordered boxes. Each field provides a
 **Generate Ideas** button above the input and AI suggestions appear as pill
 buttons. Missing data remains highlighted in two columns below the extracted
 values. After uploading a file a small success message with a 🔥 icon confirms
-that the extraction finished. You can also paste a job ad URL to analyse the
-posting directly.
+that the extraction finished. Entering a job ad URL now triggers extraction
+automatically and the welcome page shows how many fields were filled in
+percentage.
 
 Regex patterns for key information have been tightened and now support German
 and English labels. Extracted values are validated by an LLM to increase

--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -25,7 +25,7 @@ async def dummy_create(*args, **kwargs):
 def test_suggest_benefits_functions(monkeypatch):
     tool = load_tool_module()
     monkeypatch.setattr(tool.client.chat.completions, "create", dummy_create)
-    data = {"job_title": "Engineer", "city": "Berlin"}
+    data = {"job_title": "Engineer", "city": "Metropolis"}
     out1 = asyncio.run(tool.suggest_benefits_by_title(data, 5))
     out2 = asyncio.run(tool.suggest_benefits_by_location(data, 5))
     out3 = asyncio.run(tool.suggest_benefits_competitors(data, 5))

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,25 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+def load_tool_module():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    spec = importlib.util.spec_from_file_location("tool", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+
+def test_calc_extraction_progress():
+    tool = load_tool_module()
+    tool.ss.clear()
+    tool.ss["extracted"] = {
+        "BASIC": {"job_title": tool.ExtractResult("foo", 1.0)},
+        "ROLE": {"task_list": tool.ExtractResult("bar", 1.0)},
+    }
+    pct = tool.calc_extraction_progress()
+    assert pct > 0


### PR DESCRIPTION
## Summary
- expand regional benefit suggestions
- calculate extraction progress
- auto-parse URL input on the welcome page
- document new features
- adjust benefit tests and add a progress test

## Testing
- `ruff check .`
- `black --check .`
- `mypy --ignore-missing-imports .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ddce74d88320956d74f1fdb3aaf1