### PR TITLE
feat: add conditional role detail fields

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -2549,11 +2549,39 @@ def main():
                 show_missing("innovation_expected", extr, meta_map, step_name)
             with cols[1]:
                 show_missing("on_call", extr, meta_map, step_name)
+                if ss.get("data", {}).get("on_call"):
+                    show_input(
+                        "on_call_expectations",
+                        extr.get("on_call_expectations", ExtractResult()),
+                        meta_map["on_call_expectations"],
+                        widget_prefix=step_name,
+                    )
+                else:
+                    ss["data"]["on_call_expectations"] = ""
             with cols[2]:
                 show_missing("physical_duties", extr, meta_map, step_name)
+                if ss.get("data", {}).get("physical_duties"):
+                    show_input(
+                        "physical_duties_description",
+                        extr.get("physical_duties_description", ExtractResult()),
+                        meta_map["physical_duties_description"],
+                        widget_prefix=step_name,
+                    )
+                else:
+                    ss["data"]["physical_duties_description"] = ""
             cols = st.columns(3)
             with cols[0]:
                 show_missing("travel_required", extr, meta_map, step_name)
+                travel_val = ss.get("data", {}).get("travel_required")
+                if travel_val and str(travel_val) != "No":
+                    show_input(
+                        "travel_details",
+                        extr.get("travel_details", ExtractResult()),
+                        meta_map["travel_details"],
+                        widget_prefix=step_name,
+                    )
+                else:
+                    ss["data"]["travel_details"] = ""
 
         elif step_name == "SKILLS":
             meta_map = {m["key"]: m for m in meta_fields}

--- a/tests/test_role_fields.py
+++ b/tests/test_role_fields.py
@@ -1,0 +1,23 @@
+import importlib.util
+import os
+from pathlib import Path
+
+
+def load_tool_module():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    spec = importlib.util.spec_from_file_location("tool", path)
+    module = importlib.util.module_from_spec(spec)
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_conditional_role_fields_present():
+    tool = load_tool_module()
+    keys = {m["key"] for m in tool.SCHEMA["ROLE"]}
+    assert {
+        "travel_details",
+        "on_call_expectations",
+        "physical_duties_description",
+    } <= keys
+    assert tool.KEY_TO_STEP["travel_details"] == "ROLE"

--- a/wizard_schema.csv
+++ b/wizard_schema.csv
@@ -54,8 +54,11 @@ ROLE,decision_authority,checkbox,0,Decision Authority,,Entscheidungskompetenz
 ROLE,process_improvement,checkbox,0,Process Improvement,,Prozessoptimierung gefragt?
 ROLE,innovation_expected,checkbox,0,Innovation Expected,,Innovationsgrad gefordert?
 ROLE,travel_required,selectbox,0,Travel Required,No;Rarely;Occasionally;Regularly;Frequently,Reiseanteil
+ROLE,travel_details,text_input,0,Travel Details,,Häufigkeit oder Prozent der Reisetätigkeit
 ROLE,on_call,checkbox,0,On Call,,Bereitschaftsdienst?
+ROLE,on_call_expectations,text_input,0,On Call Times,,Erwartete Bereitschaftszeiten
 ROLE,physical_duties,checkbox,0,Physical Duties,,Physisch anstrengende Tätigkeit?
+ROLE,physical_duties_description,text_area,0,Physical Duties Description,,Beschreibung der körperlichen Tätigkeiten
 ROLE,daily_tools,text_area,0,Daily Tools,,Tägliche Tools/Programme
 SKILLS,seniority_level,selectbox,1,Seniority Level,Junior;Professional;Senior;Lead;Head;C-Level;Student;Intern,Karrierestufe auswählen
 SKILLS,must_have_skills,text_area,1,Must Have Skills,,Erforderliche Kompetenzen/Skills


### PR DESCRIPTION
## Summary
- ask for extra details when on-call or physical duties are checked
- request travel details when travel is required
- store metadata for new inputs in `wizard_schema.csv`
- cover the conditional fields via unit test

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `mypy --ignore-missing-imports Recruitment_Need_Analysis_Tool.py tests/test_role_fields.py` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68740d9efde8832085b44cdbad26356f