### PR TITLE
feat: sync remote policy with work schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ app proposes local perks such as club memberships or discounted facilities
 (e.g. "Fortuna Düsseldorf" membership). Regional perks now also exist for
 Berlin, München, Hamburg and Frankfurt.
 
+Remote policy is automatically synced with the selected work schedule.
+Choosing "Hybrid" directly asks for the remote percentage once.
+
 The **COMPANY & DEPARTMENT** step groups company info in a cleaner layout. The
 *Team & Culture Context* now shows three bordered boxes. Each field provides a
 **Generate Ideas** button above the input and AI suggestions appear as pill

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,3 +51,27 @@ def test_sanitize_value():
     assert tool.sanitize_value("  Foo \n") == "Foo"
     assert tool.sanitize_value(12.0) == "12"
     assert tool.sanitize_value(None) is None
+
+
+def test_sync_remote_policy_hybrid():
+    tool = load_tool_module()
+    data = {"work_schedule": "Hybrid"}
+    tool.sync_remote_policy(data)
+    assert data["remote_policy"] == "Hybrid"
+    assert data["remote_percentage"] == 50
+
+
+def test_sync_remote_policy_remote():
+    tool = load_tool_module()
+    data = {"work_schedule": "Remote"}
+    tool.sync_remote_policy(data)
+    assert data["remote_policy"] == "Remote"
+    assert data["remote_percentage"] == 100
+
+
+def test_sync_remote_policy_other():
+    tool = load_tool_module()
+    data = {"work_schedule": "Full-time"}
+    tool.sync_remote_policy(data)
+    assert data["remote_policy"] == "Onsite"
+    assert "remote_percentage" not in data


### PR DESCRIPTION
## Summary
- keep benefits and work schedule in sync
- ask for remote percentage when selecting Hybrid once
- document remote policy behaviour
- test sync_remote_policy helper

## Testing
- `ruff check .`
- `black --check Recruitment_Need_Analysis_Tool.py tests/test_utils.py`
- `mypy --ignore-missing-imports Recruitment_Need_Analysis_Tool.py` *(fails: Interrupted)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740ddde4288320a45d0105304a7a1e