### PR TITLE
feat: add progress bar and highlight required fields

### DIFF
--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -23,3 +23,13 @@ def test_calc_extraction_progress():
     }
     pct = tool.calc_extraction_progress()
     assert pct > 0
+
+
+def test_calc_required_completion():
+    tool = load_tool_module()
+    tool.ss.clear()
+    tool.ss["data"] = {}
+    start = tool.calc_required_completion()
+    tool.ss["data"]["job_title"] = "foo"
+    later = tool.calc_required_completion()
+    assert later > start


### PR DESCRIPTION
## Summary
- highlight missing mandatory fields in red
- show placeholder for missing required inputs
- add progress bar for overall completeness
- provide utility `calc_required_completion`
- cover new logic with tests

## Testing
- `ruff check Recruitment_Need_Analysis_Tool.py tests/test_progress.py`
- `black Recruitment_Need_Analysis_Tool.py tests/test_progress.py --check`
- `mypy Recruitment_Need_Analysis_Tool.py --follow-imports=skip --ignore-missing-imports --install-types --non-interactive`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740e76d8c48320b4a2ee089b5811f7