### PR TITLE
feat: export docs with logo and fonts

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -58,6 +58,8 @@ _file_tools = importlib.util.module_from_spec(_spec)
 assert _spec.loader is not None
 _spec.loader.exec_module(_file_tools)
 extract_text_from_file = _file_tools.extract_text_from_file
+create_pdf = _file_tools.create_pdf
+create_docx = _file_tools.create_docx
 
 _vs_spec = importlib.util.spec_from_file_location(
     "vector_search",
@@ -3100,6 +3102,17 @@ def main():
         st.subheader("Expected Annual Salary")
         display_salary_plot()
 
+        ss.setdefault("font_choice", "Arial")
+        st.selectbox(
+            "Font",
+            ["Arial", "Helvetica", "Courier", "Times"],
+            key="font_choice",
+        )
+        logo_file = st.file_uploader(
+            "Upload Logo", type=["png", "jpg", "jpeg"], key="logo_file"
+        )
+        logo_bytes = logo_file.getvalue() if logo_file else None
+
         st.header("Next Step – Use the collected data!")
 
         btn_cols = st.columns(6)
@@ -3171,6 +3184,28 @@ def main():
                 st.text_area("Change Request", key=f"chg_{key}", value="")
                 st.button(
                     "Apply", key=f"apply_{key}", on_click=apply_change, args=(key,)
+                )
+                pdf_bytes = create_pdf(
+                    ss[f"out_{key}"],
+                    font=ss.get("font_choice", "Arial"),
+                    logo=logo_bytes,
+                )
+                st.download_button(
+                    "Download PDF",
+                    pdf_bytes,
+                    file_name=f"{key}.pdf",
+                    mime="application/pdf",
+                )
+                doc_bytes = create_docx(
+                    ss[f"out_{key}"],
+                    font=ss.get("font_choice", "Arial"),
+                    logo=logo_bytes,
+                )
+                st.download_button(
+                    "Download DOCX",
+                    doc_bytes,
+                    file_name=f"{key}.docx",
+                    mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                 )
 
         step_labels = [title for title, _ in STEPS]

--- a/file_tools.py
+++ b/file_tools.py
@@ -6,7 +6,9 @@ import io
 import logging
 
 from PyPDF2 import PdfReader
+from fpdf import FPDF
 import docx
+from docx.shared import Inches
 
 
 def extract_text_from_file(file_data: bytes, file_type: str) -> str:
@@ -33,3 +35,43 @@ def extract_text_from_file(file_data: bytes, file_type: str) -> str:
     except Exception as exc:  # pragma: no cover - log only
         logging.error("Error reading file: %s", exc)
     return text
+
+
+def create_pdf(text: str, *, font: str = "Arial", logo: bytes | None = None) -> bytes:
+    """Return text as PDF bytes with optional logo and font."""
+
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    try:
+        pdf.set_font(font, size=12)
+    except Exception:
+        pdf.set_font("Arial", size=12)
+
+    if logo:
+        with io.BytesIO(logo) as buf:
+            pdf.image(buf, x=10, y=8, w=30)
+        pdf.ln(25)
+
+    for line in text.splitlines():
+        pdf.multi_cell(0, 10, text=line)
+    return bytes(pdf.output())
+
+
+def create_docx(text: str, *, font: str = "Arial", logo: bytes | None = None) -> bytes:
+    """Return text as Word bytes with optional logo and font."""
+
+    doc = docx.Document()
+    style = doc.styles["Normal"].font
+    style.name = font
+
+    if logo:
+        with io.BytesIO(logo) as buf:
+            doc.add_picture(buf, width=Inches(1.0))
+
+    for line in text.splitlines():
+        doc.add_paragraph(line)
+
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -16,6 +16,8 @@ def load_file_tools():
 
 
 extract_text_from_file = load_file_tools().extract_text_from_file
+create_pdf = load_file_tools().create_pdf
+create_docx = load_file_tools().create_docx
 
 
 def test_extract_text_from_pdf(tmp_path: Path) -> None:
@@ -50,3 +52,13 @@ def test_extract_text_handles_errors() -> None:
         )
         == ""
     )
+
+
+def test_create_pdf_and_docx() -> None:
+    logo = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\x0d\n\x2d\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+    pdf_bytes = create_pdf("Hello PDF", font="Arial", logo=logo)
+    assert pdf_bytes.startswith(b"%PDF")
+
+    docx_bytes = create_docx("Hello DOCX", font="Arial", logo=logo)
+    doc = docx.Document(io.BytesIO(docx_bytes))
+    assert doc.paragraphs[-1].text == "Hello DOCX"


### PR DESCRIPTION
## Summary
- allow exporting text as PDF or DOCX with optional font and logo
- support download buttons in the summary step
- add tests for new PDF/DOCX creation helpers

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`
- `mypy file_tools.py Recruitment_Need_Analysis_Tool.py tests/test_file_tools.py` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68741733d5a48320b50c413df3799b99