### PR TITLE
feat: enhance travel and on-call inputs

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -1367,6 +1367,36 @@ def show_input(
             label, value=str(val).lower() == "true", key=widget_key, help=helptext
         )
 
+    elif field_type == "week_schedule":
+        st.markdown(label)
+        try:
+            schedule = json.loads(val) if val else {}
+        except Exception:
+            schedule = {}
+        result: dict[str, list[str]] = {}
+        days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+        for day in days:
+            times = schedule.get(day, ["08:00", "17:00"])
+            try:
+                start_default = dt.datetime.strptime(times[0], "%H:%M").time()
+            except Exception:
+                start_default = dt.time(8, 0)
+            try:
+                end_default = dt.datetime.strptime(times[1], "%H:%M").time()
+            except Exception:
+                end_default = dt.time(17, 0)
+            cols = st.columns(2)
+            with cols[0]:
+                start = st.time_input(
+                    f"{day} start", value=start_default, key=f"{widget_key}_{day}_s"
+                )
+            with cols[1]:
+                end = st.time_input(
+                    f"{day} end", value=end_default, key=f"{widget_key}_{day}_e"
+                )
+            result[day] = [start.strftime("%H:%M"), end.strftime("%H:%M")]
+        val = json.dumps(result)
+
     elif field_type == "slider":
         digits = [int(x) for x in re.findall(r"\d+", str(val))]
         title = str(ss.get("data", {}).get("job_title", ""))
@@ -2732,13 +2762,51 @@ def main():
                 travel_val = ss.get("data", {}).get("travel_required")
                 if travel_val and str(travel_val) != "No":
                     show_input(
+                        "travel_region",
+                        extr.get("travel_region", ExtractResult()),
+                        meta_map["travel_region"],
+                        widget_prefix=step_name,
+                    )
+                    show_input(
+                        "travel_length_days",
+                        extr.get("travel_length_days", ExtractResult()),
+                        meta_map["travel_length_days"],
+                        widget_prefix=step_name,
+                    )
+                    show_input(
+                        "travel_frequency_number",
+                        extr.get("travel_frequency_number", ExtractResult()),
+                        meta_map["travel_frequency_number"],
+                        widget_prefix=step_name,
+                    )
+                    show_input(
+                        "travel_frequency_unit",
+                        extr.get("travel_frequency_unit", ExtractResult()),
+                        meta_map["travel_frequency_unit"],
+                        widget_prefix=step_name,
+                    )
+                    show_input(
+                        "weekend_travel",
+                        extr.get("weekend_travel", ExtractResult()),
+                        meta_map["weekend_travel"],
+                        widget_prefix=step_name,
+                    )
+                    show_input(
                         "travel_details",
                         extr.get("travel_details", ExtractResult()),
                         meta_map["travel_details"],
                         widget_prefix=step_name,
                     )
                 else:
-                    ss["data"]["travel_details"] = ""
+                    for k in [
+                        "travel_region",
+                        "travel_length_days",
+                        "travel_frequency_number",
+                        "travel_frequency_unit",
+                        "weekend_travel",
+                        "travel_details",
+                    ]:
+                        ss["data"][k] = ""
 
         elif step_name == "SKILLS":
             meta_map = {m["key"]: m for m in meta_fields}

--- a/tests/test_role_fields.py
+++ b/tests/test_role_fields.py
@@ -17,6 +17,11 @@ def test_conditional_role_fields_present():
     keys = {m["key"] for m in tool.SCHEMA["ROLE"]}
     assert {
         "travel_details",
+        "travel_region",
+        "travel_length_days",
+        "travel_frequency_number",
+        "travel_frequency_unit",
+        "weekend_travel",
         "on_call_expectations",
         "physical_duties_description",
     } <= keys

--- a/wizard_schema.csv
+++ b/wizard_schema.csv
@@ -55,9 +55,14 @@ ROLE,decision_authority,checkbox,0,Decision Authority,,Entscheidungskompetenz
 ROLE,process_improvement,checkbox,0,Process Improvement,,Prozessoptimierung gefragt?
 ROLE,innovation_expected,checkbox,0,Innovation Expected,,Innovationsgrad gefordert?
 ROLE,travel_required,selectbox,0,Travel Required,No;Rarely;Occasionally;Regularly;Frequently,Reiseanteil
-ROLE,travel_details,text_input,0,Travel Details,,Häufigkeit oder Prozent der Reisetätigkeit
+ROLE,travel_details,text_area,0,Travel Details,,Zusätzliche Hinweise zur Reisetätigkeit
+ROLE,travel_region,text_input,0,Travel Region,,Region oder Länder
+ROLE,travel_length_days,number_input,0,Travel Length (days),,Dauer je Reise
+ROLE,travel_frequency_number,number_input,0,Travel Frequency,,Anzahl der Reisen
+ROLE,travel_frequency_unit,selectbox,0,Frequency Unit,per week;per month;per quarter;per year,Zeitraum der Reisetätigkeit
+ROLE,weekend_travel,checkbox,0,Weekend Travel?,,Wochenendreisen notwendig?
 ROLE,on_call,checkbox,0,On Call,,Bereitschaftsdienst?
-ROLE,on_call_expectations,text_input,0,On Call Times,,Erwartete Bereitschaftszeiten
+ROLE,on_call_expectations,week_schedule,0,On Call Times,,Bereitschaftszeiten pro Tag
 ROLE,physical_duties,checkbox,0,Physical Duties,,Physisch anstrengende Tätigkeit?
 ROLE,physical_duties_description,text_area,0,Physical Duties Description,,Beschreibung der körperlichen Tätigkeiten
 ROLE,daily_tools,text_area,0,Daily Tools,,Tägliche Tools/Programme


### PR DESCRIPTION
## Summary
- expand travel details to capture region, length, frequency and weekend work
- replace on-call text field with weekly schedule widget
- adapt schema and tests accordingly

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68741ab76eb48320a088e28338195f0d