### PR TITLE
feat: add task suggestion functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The **ROLE & TASKS** step now features a *Generate Role Description* button
 that drafts a short description using similar job ads. In the **INTERVIEW**
 step you can also request suggested recruitment steps and sample interview
 questions.
+You can now generate task suggestions via OpenAI or the ESCO API. Each
+suggested task appears as a pill button and selections are stored under
+"selected_tasks".
 
 The **COMPANY & DEPARTMENT** step groups company info in a cleaner layout. The
 *Team & Culture Context* now shows three bordered boxes. Each field provides a

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,37 @@
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+import types
+
+
+def load_tool_module():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    spec = importlib.util.spec_from_file_location("tool", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    spec.loader.exec_module(module)
+    return module
+
+
+async def dummy_create(*args, **kwargs):
+    msg = types.SimpleNamespace(content='{"tasks": ["T1", "T2"]}')
+    return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg)])
+
+
+def test_task_functions(monkeypatch):
+    tool = load_tool_module()
+    monkeypatch.setattr(tool.client.chat.completions, "create", dummy_create)
+    ai = asyncio.run(tool.suggest_tasks({"job_title": "Dev"}))
+    assert ai == ["T1", "T2"]
+
+    monkeypatch.setattr(tool, "search_occupations", lambda q, limit=1: [{"uri": "u"}])
+    monkeypatch.setattr(
+        tool,
+        "get_skills_for_occupation",
+        lambda uri, limit=10: [{"title": "A"}, {"label": "B"}],
+    )
+    esco = tool.get_esco_tasks("dev")
+    assert esco == ["A", "B"]


### PR DESCRIPTION
## Summary
- implement get_esco_tasks and suggest_tasks
- show AI and ESCO task suggestions in the Role & Tasks step
- store chosen tasks in `selected_tasks` and display them in sidebar and summary
- document new behaviour in README
- add tests for new helper functions

## Testing
- `ruff check Recruitment_Need_Analysis_Tool.py esco_api.py file_tools.py services tests`
- `black Recruitment_Need_Analysis_Tool.py esco_api.py file_tools.py services tests --check`
- `pytest tests/test_tasks.py -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68741c8605488320b5817242d54043a9