### PR TITLE
feat: show sidebar placeholder before data

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ message with a 🔥 icon confirms
 that the extraction finished. Entering a job ad URL now triggers extraction
 automatically and the welcome page shows how many fields were filled in
 percentage.
+Until you provide data the sidebar displays a short note telling you where
+all collected information will appear.
 
 Regex patterns for key information have been tightened and now support German
 and English labels. Extracted values are validated by an LLM to increase

--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -321,6 +321,15 @@ SIDEBAR_TITLES = {
     },
 }
 
+# Sidebar placeholder shown before any data is entered
+SIDEBAR_PLACEHOLDER = {
+    "Deutsch": (
+        "Hier werden wir alle gesammelten Informationen zu Deiner Vakanz "
+        "präsentieren."
+    ),
+    "English": ("Here we will present all collected information about your vacancy."),
+}
+
 STEPS: list[tuple[str, list[str]]] = [
     (
         STEP_TITLES.get(name, name.title().replace("_", " ")),
@@ -1981,6 +1990,18 @@ def display_sidebar_data(current_step: int, lang: str) -> None:
     extracted = st.session_state.get("extracted", {})
     order = st.session_state.get("ORDER")
     if not order:
+        return
+
+    # Show placeholder if no values have been collected yet
+    has_content = False
+    for step in order:
+        values = {k: data.get(k) for k in extracted.get(step, {}) if data.get(k)}
+        has_tasks = step == "ROLE" and st.session_state.get("selected_tasks")
+        if values or has_tasks:
+            has_content = True
+            break
+    if not has_content:
+        st.sidebar.write(SIDEBAR_PLACEHOLDER.get(lang, SIDEBAR_PLACEHOLDER["English"]))
         return
 
     titles = SIDEBAR_TITLES.get(lang, SIDEBAR_TITLES["English"])


### PR DESCRIPTION
## Summary
- show a placeholder message in the sidebar before any data is collected
- update documentation with sidebar info

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742b57fd48832094b100a8ef318dd4