### PR TITLE
Handle long lines in PDF export

### DIFF
--- a/file_tools.py
+++ b/file_tools.py
@@ -7,6 +7,7 @@ import logging
 
 from PyPDF2 import PdfReader
 from fpdf import FPDF
+from fpdf.enums import WrapMode
 import docx
 from docx.shared import Inches
 
@@ -54,7 +55,11 @@ def create_pdf(text: str, *, font: str = "Arial", logo: bytes | None = None) -> 
         pdf.ln(25)
 
     for line in text.splitlines():
-        pdf.multi_cell(0, 10, text=line)
+        try:
+            pdf.multi_cell(0, 10, text=line)
+        except Exception as exc:  # pragma: no cover - log only
+            logging.error("PDF line too wide: %s", exc)
+            pdf.multi_cell(0, 10, text=line, wrapmode=WrapMode.CHAR)
     return bytes(pdf.output())
 
 

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -62,3 +62,9 @@ def test_create_pdf_and_docx() -> None:
     docx_bytes = create_docx("Hello DOCX", font="Arial", logo=logo)
     doc = docx.Document(io.BytesIO(docx_bytes))
     assert doc.paragraphs[-1].text == "Hello DOCX"
+
+
+def test_create_pdf_handles_long_word() -> None:
+    long_word = "A" * 1000
+    pdf_bytes = create_pdf(long_word, font="Arial")
+    assert pdf_bytes.startswith(b"%PDF")


### PR DESCRIPTION
## Summary
- catch FPDF exceptions when exporting
- fallback to character wrap mode for very long words
- test PDF generation with long text

## Testing
- `ruff check file_tools.py`
- `black file_tools.py`
- `mypy file_tools.py tests/test_file_tools.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742db41da48320b83131f2f5683aeb