### PR TITLE
feat: add wizard RL scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ Missing fields can be filled via Retrieval-Augmented Generation. Relevant job ad
 and CV snippets are retrieved from the pre-trained "vacalyser" vector store and
 passed to the LLM. Set ``VACALYSER_VECTOR_STORE`` to override the default store
 ID.
+
+## Wizard RL Helpers
+
+The module ``wizard_rl.py`` contains utilities to load wizard schemas,
+convert the current session state into feature vectors and persist simple
+navigation policies. A minimal ``VacalyserWizardEnv`` environment is also
+available to experiment with reinforcement learning approaches for skipping
+irrelevant steps.

--- a/tests/test_wizard_rl.py
+++ b/tests/test_wizard_rl.py
@@ -1,0 +1,67 @@
+import importlib.util
+from pathlib import Path
+import os
+
+
+def load_module():
+    path = Path(__file__).resolve().parents[1] / "wizard_rl.py"
+    spec = importlib.util.spec_from_file_location("wizard_rl", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    import sys
+
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SIMPLE_YAML = """
+steps:
+  - name: A
+    fields:
+      - key: x
+        required: true
+  - name: B
+    fields:
+      - key: y
+        required: false
+"""
+
+
+def test_load_schema(tmp_path):
+    yaml_file = tmp_path / "schema.yaml"
+    yaml_file.write_text(SIMPLE_YAML)
+    mod = load_module()
+    schema = mod.load_wizard_schema(str(yaml_file))
+    assert schema["steps"][0]["name"] == "A"
+
+
+def test_state_to_vector():
+    mod = load_module()
+    schema = {
+        "steps": [
+            {"name": "A", "fields": [{"key": "x"}]},
+            {"name": "B", "fields": [{"key": "y"}]},
+        ]
+    }
+    state = {"wizard_step": "A", "x": "1"}
+    vec = mod.state_to_vector(state, schema)
+    assert vec.tolist() == [0.0, 1.0, 0.0]
+
+
+def test_policy_and_persistence(tmp_path):
+    mod = load_module()
+    policy = mod.WizardPolicy(["A", "B"])
+    assert policy.decide_next_step({"wizard_step": "A"}) == 1
+    file = tmp_path / "p.pkl"
+    mod.save_policy(policy, file)
+    loaded = mod.load_policy(file)
+    assert loaded.step_order == ["A", "B"]
+
+
+def test_compute_reward():
+    mod = load_module()
+    reward = mod.compute_reward(
+        {"total_steps": 3, "total_time_sec": 10, "completed": True}
+    )
+    assert reward > 0

--- a/wizard_rl.py
+++ b/wizard_rl.py
@@ -1,0 +1,168 @@
+"""Reinforcement learning helpers for the Vacalyser wizard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import pickle
+from pathlib import Path
+from typing import Any, Dict, List, TYPE_CHECKING
+
+import numpy as np
+import yaml
+
+if TYPE_CHECKING:  # pragma: no cover - import for type hints
+    import gymnasium as gym
+else:  # pragma: no cover - optional dependency
+    try:
+        import gymnasium as gym
+    except Exception:
+        gym = None
+
+
+# ---------------------------------------------------------------------------
+# Schema Loading & State Vector
+# ---------------------------------------------------------------------------
+
+
+def load_wizard_schema(path: str) -> dict:
+    """Load wizard step schema from a YAML file.
+
+    Parameters
+    ----------
+    path:
+        File path to the YAML schema.
+
+    Returns
+    -------
+    dict
+        Parsed schema dictionary.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data
+
+
+def state_to_vector(session_state: dict[str, Any], schema: dict) -> np.ndarray:
+    """Convert session state into a numerical vector.
+
+    The vector contains the current step index followed by booleans for each
+    defined field indicating whether it is present in ``session_state``.
+
+    Parameters
+    ----------
+    session_state:
+        Current session state values.
+    schema:
+        Wizard schema as returned by :func:`load_wizard_schema`.
+
+    Returns
+    -------
+    np.ndarray
+        Feature vector representation.
+    """
+    steps: List[dict] = schema.get("steps", [])
+    step_names = [s["name"] for s in steps]
+    current = session_state.get("wizard_step", step_names[0])
+    step_index = step_names.index(current) if current in step_names else 0
+    fields: List[str] = []
+    for step in steps:
+        for field in step.get("fields", []):
+            fields.append(field["key"])
+    vec = [float(step_index)]
+    for key in fields:
+        vec.append(float(bool(session_state.get(key))))
+    return np.asarray(vec, dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# Policy Classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WizardPolicy:
+    """Simple policy deciding the next step."""
+
+    step_order: List[str]
+
+    def decide_next_step(self, state: dict[str, Any]) -> int:
+        """Return index of the next step to visit."""
+        current = state.get("wizard_step", self.step_order[0])
+        try:
+            idx = self.step_order.index(current)
+        except ValueError:  # pragma: no cover - invalid state
+            idx = 0
+        return min(idx + 1, len(self.step_order) - 1)
+
+
+def heuristic_next_step(session_state: dict[str, Any], schema: dict) -> int:
+    """Baseline heuristic for next step decision."""
+    policy = WizardPolicy([s["name"] for s in schema.get("steps", [])])
+    return policy.decide_next_step(session_state)
+
+
+# ---------------------------------------------------------------------------
+# Reward & Environment
+# ---------------------------------------------------------------------------
+
+
+def compute_reward(session_metrics: dict[str, Any]) -> float:
+    """Compute reward from session metrics."""
+    steps = session_metrics.get("total_steps", 0)
+    duration = session_metrics.get("total_time_sec", 0.0)
+    completed = session_metrics.get("completed", False)
+    reward = -steps - duration * 0.1
+    if completed:
+        reward += 10.0
+    else:
+        reward -= 5.0
+    return reward
+
+
+class VacalyserWizardEnv(gym.Env):  # type: ignore[misc]
+    """Gym environment simulating the wizard."""
+
+    def __init__(self, schema: dict) -> None:
+        if gym is None:  # pragma: no cover - import guard
+            raise ImportError("gymnasium not installed")
+        self.schema = schema
+        self.step_order = [s["name"] for s in schema.get("steps", [])]
+        self.action_space = gym.spaces.Discrete(2)
+        obs_len = 1 + sum(
+            len(s.get("fields", [])) for s in self.schema.get("steps", [])
+        )
+        self.observation_space = gym.spaces.Box(low=0.0, high=1.0, shape=(obs_len,))
+        self.state: dict[str, Any] = {}
+
+    def reset(self, *, seed: int | None = None, options: dict | None = None):  # type: ignore[override]
+        super().reset(seed=seed)
+        self.state = {"wizard_step": self.step_order[0]}
+        return state_to_vector(self.state, self.schema), {}
+
+    def step(self, action: int):
+        idx = self.step_order.index(self.state.get("wizard_step"))
+        if action == 1:  # skip
+            idx = min(idx + 2, len(self.step_order) - 1)
+        else:
+            idx = min(idx + 1, len(self.step_order) - 1)
+        self.state["wizard_step"] = self.step_order[idx]
+        done = idx == len(self.step_order) - 1
+        reward = 1.0 if done else 0.0
+        return state_to_vector(self.state, self.schema), reward, done, False, {}
+
+
+# ---------------------------------------------------------------------------
+# Persistence Utilities
+# ---------------------------------------------------------------------------
+
+
+def save_policy(policy: WizardPolicy, filepath: str | Path) -> None:
+    """Serialize policy to disk using pickle."""
+    with open(filepath, "wb") as f:
+        pickle.dump(policy, f)
+
+
+def load_policy(filepath: str | Path) -> WizardPolicy:
+    """Load a pickled policy from disk."""
+    with open(filepath, "rb") as f:
+        return pickle.load(f)


### PR DESCRIPTION
## Summary
- create `wizard_rl.py` with RL helpers for wizard navigation
- log RL utility functions in new `Wizard RL Helpers` README section
- add tests for schema loader, vector creation and policy persistence

## Testing
- `ruff check wizard_rl.py tests/test_wizard_rl.py`
- `black wizard_rl.py tests/test_wizard_rl.py --check`
- `mypy wizard_rl.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687436d7a2f083209a58e961bf4f322b