### PR TITLE
Integrate target industries info

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -1057,6 +1057,14 @@ async def _suggest_benefits(data: dict, mode: str, count: int) -> list[str]:
         prefix = f"commonly offered by employers in {location}"
     else:
         prefix = f"competitors usually offer for similar '{job_title}' roles"
+        industries = data.get("target_industries")
+        if industries:
+            ind_str = (
+                ", ".join(industries)
+                if isinstance(industries, list)
+                else str(industries)
+            )
+            prefix += f" in the following target industries: {ind_str}"
 
     prompt = (
         f"List up to {count} employee benefits {prefix}. "
@@ -1127,8 +1135,16 @@ async def suggest_team_challenges(data: dict, count: int = 5) -> list[str]:
 async def suggest_client_difficulties(data: dict, count: int = 5) -> list[str]:
     """Suggest frequent client difficulties."""
 
+    industries = data.get("target_industries")
+    extra = ""
+    if industries:
+        ind_str = (
+            ", ".join(industries) if isinstance(industries, list) else str(industries)
+        )
+        extra = f" for the following target industries: {ind_str}"
+
     prompt = (
-        f"List up to {count} client difficulties typical for the {data.get('industry', '')} industry. "
+        f"List up to {count} client difficulties typical for the {data.get('industry', '')} industry{extra}. "
         'Return JSON object {"items": [..]} with one item per list entry.'
     )
     return await _suggest_items(prompt, "items")
@@ -3471,8 +3487,9 @@ def main():
         with st.expander("All Data", expanded=False):
             display_summary()
 
-
-        # Ideal Candidate Profile is now collected in the BASIC step
+        if ss.get("data", {}).get("ideal_candidate_profile"):
+            st.subheader("Ideal Candidate Profile")
+            st.markdown(ss["data"]["ideal_candidate_profile"])
 
         st.subheader("Expected Annual Salary")
         display_salary_plot()

--- a/tests/test_target_industries.py
+++ b/tests/test_target_industries.py
@@ -1,0 +1,47 @@
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+import types
+
+
+def load_tool_module():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    spec = importlib.util.spec_from_file_location("tool", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    spec.loader.exec_module(module)
+    return module
+
+
+async def dummy_create(*args, **kwargs):
+    prompts.append(kwargs["messages"][1]["content"])
+    if "benefit" in prompts[-1]:
+        content = '{"benefits": ["B1"]}'
+    else:
+        content = '{"items": ["D1"]}'
+    msg = types.SimpleNamespace(content=content)
+    return types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg)])
+
+
+def test_prompts_include_target_industries(monkeypatch):
+    tool = load_tool_module()
+    global prompts
+    prompts = []
+    monkeypatch.setattr(tool.client.chat.completions, "create", dummy_create)
+    data = {
+        "job_title": "Engineer",
+        "industry": "IT",
+        "target_industries": ["Finance", "Healthcare"],
+    }
+    asyncio.run(tool.suggest_benefits_competitors(data, 5))
+    asyncio.run(tool.suggest_client_difficulties(data, 5))
+    assert "Finance" in prompts[0]
+    assert "Finance" in prompts[1]
+
+
+def test_ideal_candidate_profile_mapping():
+    tool = load_tool_module()
+    assert tool.KEY_TO_STEP["ideal_candidate_profile"] == "SUMMARY"

--- a/wizard_schema.csv
+++ b/wizard_schema.csv
@@ -85,7 +85,7 @@ SKILLS,leadership_competencies,checkbox,0,Leadership Competencies,,Führungskomp
 SKILLS,industry_experience,checkbox,0,Industry Experience,,Branchenerfahrung
 SKILLS,soft_requirement_details,text_area,0,Soft Requirement Details,,Weitere Anforderungen
 SKILLS,years_experience_min,number_input,0,Minimum Years Experience,,Min. Jahre Berufserfahrung
-SKILLS,ideal_candidate_profile,text_area,0,Ideal Candidate Profile,,Beschreibung Wunschkandidat:in
+SUMMARY,ideal_candidate_profile,text_area,0,Ideal Candidate Profile,,Beschreibung Wunschkandidat:in
 SKILLS,it_skills,text_area,0,IT Skills,,IT-Kenntnisse
 BENEFITS,visa_sponsorship,selectbox,0,Visa Sponsorship,No;Yes;Optional,Visa möglich?
 BENEFITS,bonus_scheme,checkbox,0,Bonus Scheme,,Bonusregelung


### PR DESCRIPTION
## Summary
- use `target_industries` in competitor benefit and client difficulty prompts
- show Ideal Candidate Profile in the final summary step
- map `ideal_candidate_profile` to SUMMARY step
- test prompt integration and mapping

## Testing
- `ruff check Recruitment_Need_Analysis_Tool.py tests/test_target_industries.py`
- `mypy Recruitment_Need_Analysis_Tool.py tests/test_target_industries.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753a1781d883208c4923488f9cf8fd