### PR TITLE
feat: add async helper and refactor callbacks

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -15,7 +15,7 @@ from functools import lru_cache
 import spacy
 from spacy.language import Language
 from dataclasses import dataclass
-from typing import Any, Literal, Sequence, cast
+from typing import Any, Literal, Sequence, cast, Awaitable
 
 from io import BytesIO
 from pathlib import Path
@@ -32,6 +32,21 @@ import datetime as dt
 import csv
 import base64
 import hashlib
+
+
+async def _run_async(coro: Awaitable[Any]) -> Any:
+    """Run async coroutine from sync context without closing existing loop."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+    else:
+        return await coro
+
 
 _esco_spec = importlib.util.spec_from_file_location(
     "esco_api", Path(__file__).with_name("esco_api.py")
@@ -2317,7 +2332,7 @@ def scroll_to_top() -> None:
     )
 
 
-def main():
+async def main() -> None:
     st.set_page_config(
         page_title="🧭 Recruitment Need Analysis Tool",
         page_icon="🧭",
@@ -2404,7 +2419,7 @@ def main():
                     with st.spinner("Extracting…"):
                         text = http_text(url)
                         if text:
-                            flat = asyncio.run(extract(text))
+                            flat = await _run_async(extract(text))
                             ss["extracted"] = group_by_step(flat)
                             title_res = (
                                 ss["extracted"].get("BASIC", {}).get("job_title")
@@ -2459,7 +2474,7 @@ def main():
                 with status_box.container():
                     with st.spinner("Extracting…"):
                         text = extract_text_from_file(file_bytes, up.type)
-                        flat = asyncio.run(extract(text))
+                        flat = await _run_async(extract(text))
                         ss["extracted"] = group_by_step(flat)
                         title_res = ss["extracted"].get("BASIC", {}).get("job_title")
                         if isinstance(title_res, ExtractResult) and title_res.value:
@@ -2691,14 +2706,14 @@ def main():
                     if row[1].button("Generate Ideas", key="gen_tech_stack"):
                         with st.spinner("Generating…"):
                             try:
-                                ss["tech_stack_suggestions"] = asyncio.run(
+                                ss["tech_stack_suggestions"] = await _run_async(
                                     suggest_tech_stack(ss["data"])
                                 )
                             except Exception as e:
                                 logging.error("tech stack suggestion failed: %s", e)
                                 ss["tech_stack_suggestions"] = []
                     show_missing("tech_stack", extr, meta_map, step_name)
-                    sel_ts = st.pills(
+                    sel_ts: list[str] | None = st.pills(
                         "",
                         ss.get("tech_stack_suggestions", []),
                         selection_mode="multi",
@@ -2721,14 +2736,14 @@ def main():
                     if row[1].button("Generate Ideas", key="gen_team_challenges"):
                         with st.spinner("Generating…"):
                             try:
-                                ss["team_challenges_suggestions"] = asyncio.run(
+                                ss["team_challenges_suggestions"] = await _run_async(
                                     suggest_team_challenges(ss["data"])
                                 )
                             except Exception as e:
                                 logging.error("team challenge suggestion failed: %s", e)
                                 ss["team_challenges_suggestions"] = []
                     show_missing("team_challenges", extr, meta_map, step_name)
-                    sel_tc = st.pills(
+                    sel_tc: list[str] | None = st.pills(
                         "",
                         ss.get("team_challenges_suggestions", []),
                         selection_mode="multi",
@@ -2744,8 +2759,10 @@ def main():
                     if row[1].button("Generate Ideas", key="gen_client_difficulties"):
                         with st.spinner("Generating…"):
                             try:
-                                ss["client_difficulties_suggestions"] = asyncio.run(
-                                    suggest_client_difficulties(ss["data"])
+                                ss["client_difficulties_suggestions"] = (
+                                    await _run_async(
+                                        suggest_client_difficulties(ss["data"])
+                                    )
                                 )
                             except Exception as e:
                                 logging.error(
@@ -2753,7 +2770,7 @@ def main():
                                 )
                                 ss["client_difficulties_suggestions"] = []
                     show_missing("client_difficulties", extr, meta_map, step_name)
-                    sel_cd = st.pills(
+                    sel_cd: list[str] | None = st.pills(
                         "",
                         ss.get("client_difficulties_suggestions", []),
                         selection_mode="multi",
@@ -2776,14 +2793,16 @@ def main():
                     if row[1].button("Generate Ideas", key="gen_recent_team_changes"):
                         with st.spinner("Generating…"):
                             try:
-                                ss["recent_team_changes_suggestions"] = asyncio.run(
-                                    suggest_recent_team_changes(ss["data"])
+                                ss["recent_team_changes_suggestions"] = (
+                                    await _run_async(
+                                        suggest_recent_team_changes(ss["data"])
+                                    )
                                 )
                             except Exception as e:
                                 logging.error("recent changes suggestion failed: %s", e)
                                 ss["recent_team_changes_suggestions"] = []
                     show_missing("recent_team_changes", extr, meta_map, step_name)
-                    sel_rc = st.pills(
+                    sel_rc: list[str] | None = st.pills(
                         "",
                         ss.get("recent_team_changes_suggestions", []),
                         selection_mode="multi",
@@ -2879,7 +2898,7 @@ def main():
             if row[1].button("AI Tasks", key="gen_ai_tasks"):
                 with st.spinner("Generating…"):
                     try:
-                        ss["ai_task_suggestions"] = asyncio.run(
+                        ss["ai_task_suggestions"] = await _run_async(
                             suggest_tasks(ss["data"])
                         )
                     except Exception as e:
@@ -2893,13 +2912,13 @@ def main():
                     except Exception as e:
                         logging.error("ESCO task lookup failed: %s", e)
                         ss["esco_task_suggestions"] = []
-            ai_sel = st.pills(
+            ai_sel: list[str] | None = st.pills(
                 "",
                 ss.get("ai_task_suggestions", []),
                 selection_mode="multi",
                 key="sel_ai_tasks",
             )
-            esco_sel = st.pills(
+            esco_sel: list[str] | None = st.pills(
                 "",
                 ss.get("esco_task_suggestions", []),
                 selection_mode="multi",
@@ -3140,14 +3159,14 @@ def main():
                             key="commission_structure",
                         )
                         ss["data"]["commission_structure"] = txt
-                        pct = st.number_input(
+                        pct_bonus = st.number_input(
                             meta_map["bonus_percentage"]["label"],
                             min_value=0.0,
                             max_value=100.0,
                             step=0.5,
                             key="bonus_percentage",
                         )
-                        ss["data"]["bonus_percentage"] = pct
+                        ss["data"]["bonus_percentage"] = pct_bonus
 
                 with cols_b:
                     show_missing("relocation_support", extr, meta_map, step_name)
@@ -3196,10 +3215,10 @@ def main():
             if "hard_skill_suggestions" not in ss:
                 with st.spinner("AI analysiert Skills…"):
                     try:
-                        ss["hard_skill_suggestions"] = asyncio.run(
+                        ss["hard_skill_suggestions"] = await _run_async(
                             suggest_hard_skills(ss["data"])
                         )
-                        ss["soft_skill_suggestions"] = asyncio.run(
+                        ss["soft_skill_suggestions"] = await _run_async(
                             suggest_soft_skills(ss["data"])
                         )
                     except Exception as e:
@@ -3372,7 +3391,7 @@ def main():
                 if st.button("Does your ideal Profile look like this?", key="gen_icp"):
                     with st.spinner("Generating…"):
                         try:
-                            ss["data"]["ideal_candidate_profile"] = asyncio.run(
+                            ss["data"]["ideal_candidate_profile"] = await _run_async(
                                 generate_ideal_candidate_profile(
                                     ss.get("data", {}), selected_tasks, selected_skills
                                 )
@@ -3406,7 +3425,7 @@ def main():
         if step_name == "BENEFITS":
             st.subheader("AI Benefit Suggestions")
 
-            def benefit_row(text: str, key: str, func) -> list[str]:
+            async def benefit_row(text: str, key: str, func) -> list[str]:
                 row = st.columns([1, 1, 6, 1])
                 with row[0]:
                     st.markdown("Generate")
@@ -3425,7 +3444,7 @@ def main():
                     if st.button("Generate", key=f"gen_{key}"):
                         with st.spinner("Generating…"):
                             try:
-                                ss[key] = asyncio.run(func(ss["data"], int(count)))
+                                ss[key] = await _run_async(func(ss["data"], int(count)))
                             except Exception as e:
                                 logging.error("benefit suggestion failed: %s", e)
                                 ss[key] = []
@@ -3434,17 +3453,17 @@ def main():
             title = ss["data"].get("job_title", "this role")
             company = ss["data"].get("company_name", "your company")
 
-            sel_title = benefit_row(
+            sel_title = await benefit_row(
                 f"Benefits for {title}",
                 "benefit_title",
                 suggest_benefits_by_title,
             )
-            sel_loc = benefit_row(
+            sel_loc = await benefit_row(
                 "local Benefits",
                 "benefit_loc",
                 suggest_benefits_by_location,
             )
-            sel_comp = benefit_row(
+            sel_comp = await benefit_row(
                 f"Benefits offered by the competitors of {company}",
                 "benefit_comp",
                 suggest_benefits_competitors,
@@ -3470,7 +3489,6 @@ def main():
         display_summary_overview()
         with st.expander("All Data", expanded=False):
             display_summary()
-
 
         # Ideal Candidate Profile is now collected in the BASIC step
 
@@ -3509,7 +3527,7 @@ def main():
                 if st.button(label, key=f"btn_{key}"):
                     if func:
                         with st.spinner("Generating…"):
-                            ss[f"out_{key}"] = asyncio.run(func(ss["data"]))
+                            ss[f"out_{key}"] = await _run_async(func(ss["data"]))
                     else:
                         if key == "salary":
                             ss[f"out_{key}"] = estimate_salary_range(
@@ -3590,4 +3608,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/tests/test_no_async_run.py
+++ b/tests/test_no_async_run.py
@@ -1,0 +1,9 @@
+import re
+from pathlib import Path
+
+
+def test_no_asyncio_run_in_callbacks():
+    path = Path(__file__).resolve().parents[1] / "Recruitment_Need_Analysis_Tool.py"
+    text = path.read_text()
+    runs = re.findall(r"asyncio\.run\(", text)
+    assert len(runs) == 1

--- a/tests/test_wizard_rl.py
+++ b/tests/test_wizard_rl.py
@@ -1,6 +1,5 @@
 import importlib.util
 from pathlib import Path
-import os
 
 
 def load_module():

--- a/wizard_rl.py
+++ b/wizard_rl.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 import pickle
 from pathlib import Path
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import Any, List, TYPE_CHECKING
 
 import numpy as np
-import yaml
+import yaml  # type: ignore
 
 if TYPE_CHECKING:  # pragma: no cover - import for type hints
     import gymnasium as gym
@@ -17,6 +17,11 @@ else:  # pragma: no cover - optional dependency
         import gymnasium as gym
     except Exception:
         gym = None
+
+if gym is None:  # pragma: no cover - define placeholder
+    GymEnv = object  # type: ignore[misc, assignment]
+else:
+    GymEnv = gym.Env  # type: ignore[misc, assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -119,7 +124,7 @@ def compute_reward(session_metrics: dict[str, Any]) -> float:
     return reward
 
 
-class VacalyserWizardEnv(gym.Env):  # type: ignore[misc]
+class VacalyserWizardEnv(GymEnv):  # type: ignore[misc]
     """Gym environment simulating the wizard."""
 
     def __init__(self, schema: dict) -> None:
@@ -135,7 +140,8 @@ class VacalyserWizardEnv(gym.Env):  # type: ignore[misc]
         self.state: dict[str, Any] = {}
 
     def reset(self, *, seed: int | None = None, options: dict | None = None):  # type: ignore[override]
-        super().reset(seed=seed)
+        if gym is not None:
+            super().reset(seed=seed)  # type: ignore[misc]
         self.state = {"wizard_step": self.step_order[0]}
         return state_to_vector(self.state, self.schema), {}
 


### PR DESCRIPTION
## Summary
- introduce `_run_async` to manage event loops
- convert callbacks in `Recruitment_Need_Analysis_Tool.py` to use it
- adjust wizard RL helpers for optional gymnasium
- enforce absence of direct `asyncio.run` via new test

## Testing
- `ruff check wizard_rl.py tests/test_wizard_rl.py`
- `black --check .`
- `mypy --ignore-missing-imports .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753a2dc3608320890e3a5188271e13