### PR TITLE
feat: add email validation utility

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -24,7 +24,6 @@ import httpx
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
 from openai import AsyncOpenAI
-
 import importlib.util
 from dotenv import load_dotenv
 from dateutil import parser as dateparser
@@ -32,6 +31,15 @@ import datetime as dt
 import csv
 import base64
 import hashlib
+
+_forms_spec = importlib.util.spec_from_file_location(
+    "ui_forms", Path(__file__).with_name("ui_forms.py")
+)
+assert _forms_spec is not None
+_forms_module = importlib.util.module_from_spec(_forms_spec)
+assert _forms_spec.loader is not None
+_forms_spec.loader.exec_module(_forms_module)
+email_input = _forms_module.email_input
 
 _esco_spec = importlib.util.spec_from_file_location(
     "esco_api", Path(__file__).with_name("esco_api.py")
@@ -1509,13 +1517,16 @@ def show_input(
                 st.warning("Entered salary deviates from suggestion.")
 
     else:
-        val = st.text_input(
-            label,
-            value=val or "",
-            key=widget_key,
-            help=helptext,
-            placeholder=placeholder,
-        )
+        if key in {"recruitment_contact_email", "line_manager_email"}:
+            val = email_input(label, key=widget_key)
+        else:
+            val = st.text_input(
+                label,
+                value=val or "",
+                key=widget_key,
+                help=helptext,
+                placeholder=placeholder,
+            )
 
     # Save to session state
     st.session_state["data"][key] = val
@@ -3470,7 +3481,6 @@ def main():
         display_summary_overview()
         with st.expander("All Data", expanded=False):
             display_summary()
-
 
         # Ideal Candidate Profile is now collected in the BASIC step
 

--- a/tests/test_email_validation.py
+++ b/tests/test_email_validation.py
@@ -1,0 +1,39 @@
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+
+def load_forms_module():
+    path = Path(__file__).resolve().parents[1] / "ui_forms.py"
+    spec = importlib.util.spec_from_file_location("forms", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "user@example.com",
+        "first.last@domain.co",
+        "name+alias@sub.domain.org",
+    ],
+)
+def test_email_regex_valid(email):
+    forms = load_forms_module()
+    assert re.match(forms.EMAIL_RE, email)
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "userexample.com",
+        "bad@domain",
+        "no space@domain.com",
+    ],
+)
+def test_email_regex_invalid(email):
+    forms = load_forms_module()
+    assert not re.match(forms.EMAIL_RE, email)

--- a/ui_forms.py
+++ b/ui_forms.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import re
+import streamlit as st
+
+EMAIL_RE = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+
+
+def email_input(label: str, key: str) -> str:
+    """Render a validated email input field.
+
+    Parameters
+    ----------
+    label : str
+        Visible label for the input field.
+    key : str
+        Session state key for Streamlit.
+
+    Returns
+    -------
+    str
+        The current value of the text input.
+    """
+
+    val = st.text_input(label, key=key)
+    if val and not re.match(EMAIL_RE, val):
+        st.error("Ungültige E-Mail Adresse")
+    return val


### PR DESCRIPTION
## Summary
- add `email_input` helper in new `ui_forms` module
- validate recruitment and line manager email fields
- cover regex behavior with unit tests

## Testing
- `ruff check Recruitment_Need_Analysis_Tool.py ui_forms.py tests/test_email_validation.py`
- `mypy ui_forms.py`
- `mypy Recruitment_Need_Analysis_Tool.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753a3bfa54832089917ad27273886b