### PR TITLE
fix: correct language count

### DIFF
--- a/Recruitment_Need_Analysis_Tool.py
+++ b/Recruitment_Need_Analysis_Tool.py
@@ -47,7 +47,6 @@ async def _run_async(coro: Awaitable[Any]) -> Any:
         return await coro
 
 
-
 _esco_spec = importlib.util.spec_from_file_location(
     "esco_api", Path(__file__).with_name("esco_api.py")
 )
@@ -75,6 +74,15 @@ _spec.loader.exec_module(_file_tools)
 extract_text_from_file = _file_tools.extract_text_from_file
 create_pdf = _file_tools.create_pdf
 create_docx = _file_tools.create_docx
+
+_ui_spec = importlib.util.spec_from_file_location(
+    "ui_forms", Path(__file__).with_name("ui_forms.py")
+)
+assert _ui_spec is not None
+_ui_mod = importlib.util.module_from_spec(_ui_spec)
+assert _ui_spec.loader is not None
+_ui_spec.loader.exec_module(_ui_mod)
+email_input = _ui_mod.email_input
 
 _vs_spec = importlib.util.spec_from_file_location(
     "vector_search",
@@ -2738,7 +2746,6 @@ async def main() -> None:
                         with st.spinner("Generating…"):
                             try:
                                 ss["tech_stack_suggestions"] = await _run_async(
-
                                     suggest_tech_stack(ss["data"])
                                 )
                             except Exception as e:
@@ -2746,7 +2753,6 @@ async def main() -> None:
                                 ss["tech_stack_suggestions"] = []
                     show_missing("tech_stack", extr, meta_map, step_name)
                     sel_ts: list[str] | None = st.pills(
-
                         "",
                         ss.get("team_tech_stack_suggestions", []),
                         selection_mode="multi",
@@ -2886,7 +2892,7 @@ async def main() -> None:
             if st.button("Generate Role Description", key="gen_role_desc"):
                 with st.spinner("Generating …"):
                     try:
-                        ss["data"]["role_description"] = asyncio.run(
+                        ss["data"]["role_description"] = await _run_async(
                             suggest_role_description(ss["data"])
                         )
                     except Exception as e:  # pragma: no cover - log only
@@ -3540,8 +3546,6 @@ async def main() -> None:
         display_summary_overview()
         with st.expander("All Data", expanded=False):
             display_summary()
-
-
 
         if ss.get("data", {}).get("ideal_candidate_profile"):
             st.subheader("Ideal Candidate Profile")

--- a/esco_api.py
+++ b/esco_api.py
@@ -200,5 +200,5 @@ def get_occupation_statistics(occupation_uri: str) -> dict[str, Any]:
     skills = get_skills_for_occupation(occupation_uri)
     return {
         "skills": len(skills),
-        "languages": len(details.get("preferredLabel", {})),
+        "languages": 1 if details.get("preferredLabel") else 0,
     }

--- a/tests/test_esco.py
+++ b/tests/test_esco.py
@@ -99,3 +99,15 @@ def test_related_and_categories(monkeypatch):
     monkeypatch.setattr(mod.httpx, "get", DummyClient(cat_data).get)
     cats = mod.get_skill_categories("suri")
     assert cats == ["c"]
+
+
+def test_get_occupation_statistics(monkeypatch):
+    mod = load_module()
+
+    monkeypatch.setattr(
+        mod, "fetch_occupation_details", lambda uri: {"preferredLabel": "Nurse"}
+    )
+    monkeypatch.setattr(mod, "get_skills_for_occupation", lambda uri: [1, 2, 3])
+
+    stats = mod.get_occupation_statistics("uri")
+    assert stats == {"skills": 3, "languages": 1}

--- a/wizard_rl.py
+++ b/wizard_rl.py
@@ -5,18 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 import pickle
 from pathlib import Path
-from typing import Any, List, TYPE_CHECKING
+from typing import Any, List
 import numpy as np
 import yaml  # type: ignore
 
-gym: Any
 try:  # pragma: no cover - optional dependency
-    import gymnasium as gym
-else:  # pragma: no cover - optional dependency
-    try:
-        import gymnasium as gym
-    except Exception:  # pragma: no cover - optional dependency missing
-        gym = None
+    import gymnasium as gym  # type: ignore
+except Exception:  # pragma: no cover - optional dependency missing
+    gym = None
 
 if gym is None:  # pragma: no cover - define placeholder
     GymEnv = object  # type: ignore[misc, assignment]
@@ -25,11 +21,13 @@ else:
 
 
 if gym is not None:
-    BaseEnv = gym.Env
+    BaseEnv = gym.Env  # type: ignore[misc, assignment]
 else:
 
-    class BaseEnv:  # pragma: no cover - minimal stub for missing gymnasium
+    class _BaseEnv:  # pragma: no cover - minimal stub for missing gymnasium
         pass
+
+    BaseEnv = _BaseEnv
 
 
 # ---------------------------------------------------------------------------
@@ -129,15 +127,11 @@ def compute_reward(session_metrics: dict[str, Any]) -> float:
         reward += 10.0
     else:
         reward -= 5.0
+
     return reward
 
 
-
-BaseEnv: type = gym.Env if gym is not None else object
-
-
-class VacalyserWizardEnv(BaseEnv):  # type: ignore[misc]
-
+class VacalyserWizardEnv(BaseEnv):  # type: ignore[misc, valid-type]
     """Gym environment simulating the wizard."""
 
     def __init__(self, schema: dict) -> None:
@@ -150,7 +144,6 @@ class VacalyserWizardEnv(BaseEnv):  # type: ignore[misc]
             )
             self.observation_space = gym.spaces.Box(low=0.0, high=1.0, shape=(obs_len,))
         self.state: dict[str, Any] = {}
-
 
     def reset(self, *, seed: int | None = None, options: dict | None = None):
         if gym is not None:


### PR DESCRIPTION
## Summary
- fix language count in `esco_api.get_occupation_statistics`
- load `ui_forms.email_input` via dynamic import
- use `_run_async` when generating role description
- handle optional gym import for mypy
- test occupation statistics

## Testing
- `ruff check esco_api.py Recruitment_Need_Analysis_Tool.py wizard_rl.py tests/test_esco.py`
- `mypy esco_api.py Recruitment_Need_Analysis_Tool.py wizard_rl.py tests/test_esco.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755059f06c8320990b5d7a184d9d63