### PR TITLE
feat: add chat summary step

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ streamlit run app.py
 ```
 
 The interface now includes responsive CSS that stacks columns on
-smartphone screens for easier use on the go.
+smartphone screens for easier use on the go. After you answer all
+questions the assistant shows a short summary of the collected
+information so you can verify everything.
 
 The **SKILLS** step suggests additional hard and soft skills via OpenAI and
 presents them as selectable buttons. Chosen suggestions are stored in your

--- a/tests/test_chat_summary.py
+++ b/tests/test_chat_summary.py
@@ -1,0 +1,37 @@
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+
+def load_app_module():
+    path = Path(__file__).resolve().parents[1] / "app.py"
+    sys.path.insert(0, str(path.parent))
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    import streamlit as st
+
+    st.secrets = {"OPENAI_API_KEY": "test"}
+    spec = importlib.util.spec_from_file_location("app", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_format_summary():
+    app = load_app_module()
+    data = {"job_title": "Dev", "employment_type": "Full-time"}
+    text = app._format_summary(data)
+    assert "**Job Title:**" in text
+    assert "Dev" in text
+
+
+def test_display_final_summary(monkeypatch):
+    app = load_app_module()
+    state = types.SimpleNamespace(
+        data={"job_title": "Dev"}, messages=[], summary_shown=False
+    )
+    monkeypatch.setattr(app, "st", types.SimpleNamespace(session_state=state))
+    app.display_final_summary()
+    assert state.summary_shown is True
+    assert state.messages


### PR DESCRIPTION
## Summary
- display collected chat data as a final summary
- confirm completion when all questions answered
- describe new feature in README
- add unit tests for chat summary helpers

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q tests/test_chat_summary.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c4021f648320b52944783368edc7