### PR TITLE
feat: allow editing answers in chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The interface now includes responsive CSS that stacks columns on
 smartphone screens for easier use on the go. After you answer all
 questions the assistant shows a short summary of the collected
 information so you can verify everything.
+You can edit any field during the chat using commands like
+"change job title to Senior Engineer" or "skills: Python". The
+assistant confirms updates and shows the revised summary until you
+type "done" to finish.
 
 The **SKILLS** step suggests additional hard and soft skills via OpenAI and
 presents them as selectable buttons. Chosen suggestions are stored in your

--- a/tests/test_edit_commands.py
+++ b/tests/test_edit_commands.py
@@ -1,0 +1,31 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+def load_app_module():
+    path = Path(__file__).resolve().parents[1] / "app.py"
+    sys.path.insert(0, str(path.parent))
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    import streamlit as st
+
+    st.secrets = {"OPENAI_API_KEY": "test"}
+    spec = importlib.util.spec_from_file_location("app", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+
+def test_parse_edit_command_colon():
+    app = load_app_module()
+    assert app.parse_edit_command("job_title: Senior Engineer") == (
+        "job_title",
+        "Senior Engineer",
+    )
+
+
+def test_parse_edit_command_change():
+    app = load_app_module()
+    text = "Please change the company name to Tech Corp"
+    assert app.parse_edit_command(text) == ("company_name", "Tech Corp")


### PR DESCRIPTION
## Summary
- add `parse_edit_command` util
- update chat flow to support mid-flow editing and final confirmation
- document chat editing in README
- test edit command parser

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876cb122574832099d9c735615e98e4